### PR TITLE
fix: Upgrade asyncpg to 0.31.0 for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-multipart==0.0.6
 
 # Database
 sqlalchemy[asyncio]==2.0.25
-asyncpg==0.29.0
+asyncpg==0.31.0
 alembic==1.13.1
 
 # Configuration


### PR DESCRIPTION
asyncpg 0.29.0 failed to build with Python 3.13 due to C API changes (e.g., _PyLong_AsByteArray signature change, _PyInterpreterState_GetConfig removal). Version 0.30.0+ added proper Python 3.13 support.

https://claude.ai/code/session_01Kd8A833W2w3UbFNKJYEuoe