### PR TITLE
fix: Upgrade SQLAlchemy to 2.0.36 for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ uvicorn[standard]==0.27.0
 python-multipart==0.0.6
 
 # Database
-sqlalchemy[asyncio]==2.0.25
+sqlalchemy[asyncio]==2.0.36
 asyncpg==0.31.0
 alembic==1.13.1
 


### PR DESCRIPTION
SQLAlchemy 2.0.25 fails with Python 3.13 due to new class attributes (__firstlineno__, __static_attributes__) conflicting with TypingOnly validation. Version 2.0.36+ fixes this issue.

https://claude.ai/code/session_01Kd8A833W2w3UbFNKJYEuoe