### PR TITLE
fix: Auto-convert DATABASE_URL to use asyncpg driver

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -2,6 +2,7 @@
 Application Configuration
 """
 from pydantic_settings import BaseSettings
+from pydantic import field_validator
 from typing import Optional
 
 
@@ -13,6 +14,14 @@ class Settings(BaseSettings):
 
     # Database
     DATABASE_URL: str = "postgresql+asyncpg://user:password@localhost:5432/shipment_bot"
+
+    @field_validator("DATABASE_URL", mode="before")
+    @classmethod
+    def convert_database_url(cls, v: str) -> str:
+        """Convert postgresql:// to postgresql+asyncpg:// for async support"""
+        if v and v.startswith("postgresql://"):
+            return v.replace("postgresql://", "postgresql+asyncpg://", 1)
+        return v
 
     # Redis
     REDIS_URL: str = "redis://localhost:6379/0"


### PR DESCRIPTION
Render and other hosting providers set DATABASE_URL as postgresql://, but SQLAlchemy's create_async_engine requires postgresql+asyncpg://. Add a field validator to automatically convert the URL format.

https://claude.ai/code/session_01Kd8A833W2w3UbFNKJYEuoe