### PR TITLE
fix: Use per-task database sessions for Celery workers

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -1,6 +1,7 @@
 """
 Database Connection and Session Management
 """
+from contextlib import asynccontextmanager
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession, async_sessionmaker
 from sqlalchemy.orm import declarative_base
 
@@ -28,3 +29,34 @@ async def get_db() -> AsyncSession:
             yield session
         finally:
             await session.close()
+
+
+@asynccontextmanager
+async def get_task_session():
+    """
+    Create a fresh database session for Celery tasks.
+
+    This creates a new engine and session bound to the current event loop,
+    avoiding the "attached to a different loop" error that occurs when
+    reusing module-level engines across different event loops in Celery workers.
+    """
+    task_engine = create_async_engine(
+        settings.DATABASE_URL,
+        echo=settings.DEBUG,
+        pool_pre_ping=True,
+        pool_size=5,
+        max_overflow=10
+    )
+    task_session_maker = async_sessionmaker(
+        bind=task_engine,
+        class_=AsyncSession,
+        expire_on_commit=False
+    )
+
+    async with task_session_maker() as session:
+        try:
+            yield session
+        finally:
+            await session.close()
+
+    await task_engine.dispose()


### PR DESCRIPTION
Celery workers create new event loops for each task, but the module-level SQLAlchemy async engine was bound to the original event loop at import time. This caused "Task got Future attached to a different loop" errors.

Added get_task_session() context manager that creates a fresh engine and session bound to the current event loop for each task invocation.

https://claude.ai/code/session_01Kd8A833W2w3UbFNKJYEuoe