### PR TITLE
fix: Fix WhatsApp Gateway webhook URL for Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -84,7 +84,7 @@ services:
       - key: NODE_ENV
         value: production
       - key: API_WEBHOOK_URL
-        value: "http://shipment-bot-api:10000/api/whatsapp/webhook"
+        value: "https://shipment-bot-api.onrender.com/api/webhooks/whatsapp/webhook"
 
   # =====================================================
   # Redis

--- a/whatsapp_gateway/index.js
+++ b/whatsapp_gateway/index.js
@@ -13,6 +13,9 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// Get API webhook URL from environment variable
+const API_WEBHOOK_URL = process.env.API_WEBHOOK_URL || 'http://localhost:8000/api/webhooks/whatsapp/webhook';
+
 let client = null;
 let isConnected = false;
 let currentQR = null;
@@ -88,7 +91,8 @@ async function initializeClient() {
 
             // Forward to FastAPI webhook
             try {
-                const response = await fetch('http://api:8000/api/webhooks/whatsapp/webhook', {
+                console.log('Forwarding to:', API_WEBHOOK_URL);
+                const response = await fetch(API_WEBHOOK_URL, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({


### PR DESCRIPTION
- Use API_WEBHOOK_URL environment variable instead of hardcoded URL
- Update render.yaml with correct public URL for inter-service communication
- Add logging for webhook forwarding

https://claude.ai/code/session_01HsNVYYX8ruz5L6A6iTETrG