### PR TITLE
fix: Handle Render's postgres:// URL format for asyncpg

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -18,9 +18,13 @@ class Settings(BaseSettings):
     @field_validator("DATABASE_URL", mode="before")
     @classmethod
     def convert_database_url(cls, v: str) -> str:
-        """Convert postgresql:// to postgresql+asyncpg:// for async support"""
-        if v and v.startswith("postgresql://"):
-            return v.replace("postgresql://", "postgresql+asyncpg://", 1)
+        """Convert postgres:// or postgresql:// to postgresql+asyncpg:// for async support"""
+        if v:
+            # Render uses postgres:// but SQLAlchemy needs postgresql+asyncpg://
+            if v.startswith("postgres://"):
+                return v.replace("postgres://", "postgresql+asyncpg://", 1)
+            if v.startswith("postgresql://"):
+                return v.replace("postgresql://", "postgresql+asyncpg://", 1)
         return v
 
     # Redis


### PR DESCRIPTION
Render uses postgres:// but SQLAlchemy asyncpg needs postgresql+asyncpg:// The validator now handles both postgres:// and postgresql:// prefixes.

https://claude.ai/code/session_01HsNVYYX8ruz5L6A6iTETrG