### PR TITLE
fix: Update WHATSAPP_GATEWAY_URL to use public Render URL

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -34,7 +34,7 @@ services:
       - key: TELEGRAM_BOT_TOKEN
         sync: false  # Set manually in dashboard
       - key: WHATSAPP_GATEWAY_URL
-        value: "http://shipment-bot-wa-gateway:10000"
+        value: "https://shipment-bot-wa-gateway.onrender.com"
     autoDeploy: true
 
   # =====================================================
@@ -64,7 +64,7 @@ services:
       - key: TELEGRAM_BOT_TOKEN
         sync: false
       - key: WHATSAPP_GATEWAY_URL
-        value: "http://shipment-bot-wa-gateway:10000"
+        value: "https://shipment-bot-wa-gateway.onrender.com"
 
   # =====================================================
   # WhatsApp Gateway (Node.js with Docker for Chrome)


### PR DESCRIPTION
Render services cannot communicate via internal hostnames. Updated both API and worker to use the public URL.

https://claude.ai/code/session_01HsNVYYX8ruz5L6A6iTETrG