### PR TITLE
תגובת פקודת start בוט

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -14,5 +14,20 @@ router = APIRouter()
 router.include_router(deliveries_router, prefix="/deliveries", tags=["deliveries"])
 router.include_router(users_router, prefix="/users", tags=["users"])
 router.include_router(wallets_router, prefix="/wallets", tags=["wallets"])
-router.include_router(whatsapp_router, prefix="/webhooks/whatsapp", tags=["webhooks"])
-router.include_router(telegram_router, prefix="/webhooks/telegram", tags=["webhooks"])
+# Canonical webhook endpoints (documented)
+router.include_router(whatsapp_router, prefix="/whatsapp", tags=["webhooks"])
+router.include_router(telegram_router, prefix="/telegram", tags=["webhooks"])
+
+# Backwards-compatible webhook endpoints
+router.include_router(
+    whatsapp_router,
+    prefix="/webhooks/whatsapp",
+    tags=["webhooks"],
+    include_in_schema=False
+)
+router.include_router(
+    telegram_router,
+    prefix="/webhooks/telegram",
+    tags=["webhooks"],
+    include_in_schema=False
+)


### PR DESCRIPTION
Add canonical webhook routes for Telegram and WhatsApp, retaining old routes for backward compatibility, to resolve a webhook URL mismatch that caused 404 errors and prevented the Telegram bot from responding.

---
<a href="https://cursor.com/background-agent?bcId=bc-96afc2a0-42bd-47e5-b1fc-9493313b99a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-96afc2a0-42bd-47e5-b1fc-9493313b99a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

