### PR TITLE
התראות משלוחים בוט

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,8 @@ CELERY_RESULT_BACKEND=redis://localhost:6379/2
 
 # WhatsApp Gateway (Node.js microservice with WPPConnect)
 WHATSAPP_GATEWAY_URL=http://localhost:3000
+# Optional WhatsApp group ID for courier broadcasts (use @g.us suffix)
+WHATSAPP_COURIER_GROUP_ID=
 
 # Telegram Bot
 TELEGRAM_BOT_TOKEN=your_telegram_bot_token_here

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -36,6 +36,7 @@ class Settings(BaseSettings):
 
     # WhatsApp Gateway
     WHATSAPP_GATEWAY_URL: str = "http://localhost:3000"
+    WHATSAPP_COURIER_GROUP_ID: Optional[str] = None
 
     # Telegram
     TELEGRAM_BOT_TOKEN: Optional[str] = None


### PR DESCRIPTION
Add support for sending "new delivery" notifications to a WhatsApp group.

Previously, "new delivery" notifications were only sent as private broadcasts to COURIER users. This PR adds the ability to also send these notifications to a designated WhatsApp group, addressing the missing functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-de98eb76-9e90-4af7-ae36-6c2f6e4e9cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-de98eb76-9e90-4af7-ae36-6c2f6e4e9cb9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

