### PR TITLE
fix: תיקון לולאת בוט בווטסאפ - טיפול בבחירות מרשימה

### DIFF
--- a/app/state_machine/handlers.py
+++ b/app/state_machine/handlers.py
@@ -378,6 +378,12 @@ class SenderStateHandler:
         """Handle delivery location selection (within/outside city)"""
         msg = message.strip()
 
+        # לוג לדיבוג - מה בדיוק התקבל מהמשתמש
+        logger.debug(
+            "Handling delivery location input",
+            extra_data={"user_id": user_id, "raw_input": repr(msg), "input_length": len(msg)}
+        )
+
         if "בתוך" in msg or "🏙️" in msg or msg == "1":
             location_type = "within_city"
             location_text = "בתוך העיר"
@@ -385,6 +391,11 @@ class SenderStateHandler:
             location_type = "outside_city"
             location_text = "מחוץ לעיר"
         else:
+            # לוג כשהתנאי לא מתקיים - לעזור בדיבוג
+            logger.warning(
+                "Delivery location input did not match expected patterns",
+                extra_data={"user_id": user_id, "raw_input": repr(msg)}
+            )
             response = MessageResponse(
                 "אנא בחרו אפשרות:\n"
                 "1. בתוך העיר\n"


### PR DESCRIPTION
הבעיה: כאשר נשלחה הודעת רשימה (list message) למשתמש והוא בחר אפשרות, WPPConnect שלח בחזרה את ה-rowId (כגון option_0) במקום טקסט הכפתור. ה-handlers ב-Python לא זיהו את הקלט והחזירו את אותה שאלה בלולאה.

התיקון:
1. שינוי rowId להכיל את הטקסט המקורי במקום option_N
2. הוספת טיפול ב-listResponse כדי לחלץ את הטקסט הנכון מבחירת רשימה
3. שימוש ב-messageText המעודכן בפורוורד ל-API
4. הוספת לוגים ב-handlers לדיבוג בעיות עתידיות

https://claude.ai/code/session_01TnMmu7YPB9weibxEU5E45b