### PR TITLE
Fix pydantic v2 aliasing and improve smoke correlation output

### DIFF
--- a/app/api/webhooks/telegram.py
+++ b/app/api/webhooks/telegram.py
@@ -2,7 +2,7 @@
 Telegram Webhook Handler - Bot Gateway Layer
 """
 from fastapi import APIRouter, Depends, BackgroundTasks
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, ConfigDict
 from typing import Optional, List
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
@@ -42,27 +42,23 @@ class TelegramPhotoSize(BaseModel):
 
 
 class TelegramMessage(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     message_id: int
-    from_user: Optional[TelegramUser] = None
+    from_user: Optional[TelegramUser] = Field(default=None, alias="from")
     chat: TelegramChat
     text: Optional[str] = None
     photo: Optional[List[TelegramPhotoSize]] = None
     date: int
 
-    class Config:
-        populate_by_name = True
-        fields = {'from_user': 'from'}
-
 
 class TelegramCallbackQuery(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     id: str
-    from_user: Optional[TelegramUser] = None
+    from_user: Optional[TelegramUser] = Field(default=None, alias="from")
     message: Optional[TelegramMessage] = None
     data: Optional[str] = None
-
-    class Config:
-        populate_by_name = True
-        fields = {'from_user': 'from'}
 
 
 class TelegramUpdate(BaseModel):


### PR DESCRIPTION
מה  עשיתי
ניקיתי את אזהרת Pydantic v2: ב־app/api/webhooks/telegram.py החלפתי את Config.fields = {'from_user': 'from'} (שהוסר ב־v2) בפתרון תקין של v2:
from_user מוגדר עם Field(..., alias="from")
והוספתי model_config = ConfigDict(populate_by_name=True)
ניקיתי את אזהרת utcnow() ב־Python 3.13: ב־scripts/smoke_webhooks.py עברתי ל־datetime.now(timezone.utc).isoformat().
שיפרתי את ה־smoke failure output: כשיש סטטוס לא‑2xx, הסקריפט עכשיו מדפיס אוטומטית את X-Correlation-ID בתוך ה־RuntimeError, כדי שתוכל לאתר מהר את הלוגים ב־Render.
סטטוס
דחפתי קומיט 687887b לענף cursor/custom-exception-handling-ae31.
הרצתי בדיקות — 97 passed וללא warnings מהסוגים שציינת.
עכשיו כשתריץ שוב bash scripts/run_render_checks.sh, במקרה של 500 ב־Telegram webhook תקבל גם X-Correlation-ID ישר בשגיאה.