### PR TITLE
Handle telegram callback_query without message safely

### DIFF
--- a/tests/test_telegram_webhook_smoke.py
+++ b/tests/test_telegram_webhook_smoke.py
@@ -27,3 +27,26 @@ async def test_telegram_webhook_creates_user_with_phone_placeholder(test_client,
     assert user.phone_number is not None
     assert user.phone_number.startswith("tg:")
 
+
+@pytest.mark.asyncio
+async def test_telegram_callback_query_without_message_uses_from_user_id(test_client, db_session):
+    resp = await test_client.post(
+        "/api/telegram/webhook",
+        json={
+            "update_id": 2,
+            "callback_query": {
+                "id": "cb-1",
+                "data": "תפריט",
+                "from": {"id": 777, "first_name": "Cb"},
+                "message": None,
+            },
+        },
+    )
+    assert resp.status_code == 200
+
+    result = await db_session.execute(select(User).where(User.telegram_chat_id == "777"))
+    user = result.scalar_one()
+    assert user.phone_number is not None
+    assert user.phone_number != "tg:None"
+    assert user.phone_number.startswith("tg:")
+


### PR DESCRIPTION
הבאג הוא בדיוק כמו שתיארת: callback_query יכול להגיע בלי message, ואז chat_id=None היה מוביל ל־phone_number="tg:None" (לא ייחודי) ושובר unique constraint.

תיקון בקוד (app/api/webhooks/telegram.py):
הוספתי _resolve_telegram_chat_id() שמחזיר chat_id גם כשאין message ע״י fallback ל־callback.from_user.id (ב־private chats זה זהה ל־chat_id).
הוספתי guard: אם עדיין אין chat_id → לוג warning וחוזרים {"ok": True} בלי לגעת ב־DB.
הוספתי הגנה ב־_telegram_phone_placeholder() שלא יאפשר None/ריק.
טסט: הוספתי בדיקה שמכסה callback_query בלי message ומוודאת שלא נוצר tg:None.