### PR TITLE
Exponential backoff limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,11 @@ TELEGRAM_ADMIN_CHAT_ID=your_admin_chat_id_here
 DEFAULT_CREDIT_LIMIT=-500.0
 DELIVERY_FEE=10.0
 
+# Outbox retry/backoff
+# base_seconds * 2**retry_count (capped)
+OUTBOX_RETRY_BASE_SECONDS=30
+OUTBOX_MAX_BACKOFF_SECONDS=3600
+
 # File Upload
 UPLOAD_DIR=./uploads
 MAX_FILE_SIZE=10485760

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -51,6 +51,11 @@ class Settings(BaseSettings):
     DEFAULT_CREDIT_LIMIT: float = -500.0  # Minimum balance allowed (500₪ credit)
     DELIVERY_FEE: float = 10.0  # Fee per delivery
 
+    # Outbox retry/backoff
+    # Base delay is multiplied by 2**retry_count (capped by OUTBOX_MAX_BACKOFF_SECONDS)
+    OUTBOX_RETRY_BASE_SECONDS: int = 30
+    OUTBOX_MAX_BACKOFF_SECONDS: int = 3600  # 1 hour cap to prevent multi-day delays
+
     # File Upload
     UPLOAD_DIR: str = "./uploads"
     MAX_FILE_SIZE: int = 10 * 1024 * 1024  # 10MB

--- a/tests/test_outbox_backoff.py
+++ b/tests/test_outbox_backoff.py
@@ -1,0 +1,58 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from app.core.config import settings
+from app.db.models.outbox_message import MessagePlatform, MessageStatus, OutboxMessage
+from app.domain.services.outbox_service import OutboxService, _calculate_backoff_seconds
+
+
+def test_calculate_backoff_seconds_matches_previous_semantics() -> None:
+    # Previous logic was: base_seconds * (2 ** retry_count)
+    base = 30
+    max_backoff = 3600
+
+    assert _calculate_backoff_seconds(0, base_seconds=base, max_backoff_seconds=max_backoff) == 30
+    assert _calculate_backoff_seconds(1, base_seconds=base, max_backoff_seconds=max_backoff) == 60
+    assert _calculate_backoff_seconds(6, base_seconds=base, max_backoff_seconds=max_backoff) == 1920
+
+
+def test_calculate_backoff_seconds_is_capped() -> None:
+    base = 30
+    max_backoff = 3600
+
+    # 30 * 2**7 = 3840 -> capped to 3600
+    assert _calculate_backoff_seconds(7, base_seconds=base, max_backoff_seconds=max_backoff) == 3600
+    assert _calculate_backoff_seconds(10_000, base_seconds=base, max_backoff_seconds=max_backoff) == 3600
+
+
+@pytest.mark.asyncio
+async def test_mark_as_failed_sets_next_retry_at_with_cap(db_session) -> None:
+    # Set an intentionally huge retry_count to ensure we don't compute 2**retry_count.
+    msg = OutboxMessage(
+        platform=MessagePlatform.WHATSAPP,
+        recipient_id="test",
+        message_type="test",
+        message_content={"hello": "world"},
+        status=MessageStatus.PENDING,
+        retry_count=10_000,
+        max_retries=20_000,
+    )
+    db_session.add(msg)
+    await db_session.commit()
+    await db_session.refresh(msg)
+
+    svc = OutboxService(db_session)
+    before = datetime.utcnow()
+    await svc.mark_as_failed(msg.id, "boom")
+    after = datetime.utcnow()
+
+    await db_session.refresh(msg)
+    assert msg.status == MessageStatus.PENDING
+    assert msg.next_retry_at is not None
+
+    max_backoff = settings.OUTBOX_MAX_BACKOFF_SECONDS
+    lower = before + timedelta(seconds=max_backoff) - timedelta(seconds=2)
+    upper = after + timedelta(seconds=max_backoff) + timedelta(seconds=2)
+    assert lower <= msg.next_retry_at <= upper
+


### PR DESCRIPTION
Limit exponential backoff for outbox messages to prevent excessively long retry delays.

The previous exponential backoff calculation could lead to retry delays of several days for high `retry_count` values. This change introduces a configurable maximum backoff time (default 1 hour) to cap these delays and ensure messages are retried within a reasonable timeframe.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a0ae26a-2a93-41f3-9f39-0d05d282cd3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1a0ae26a-2a93-41f3-9f39-0d05d282cd3d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

