### PR TITLE
Fix ReDoc documentation endpoint with custom CDN configuration

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,7 @@ Shipment Bot - Main FastAPI Application
 """
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.docs import get_redoc_html
 
 from app.core.config import settings
 from app.core.logging import setup_logging, get_logger
@@ -30,7 +31,7 @@ app = FastAPI(
     version="1.0.0",
     description="Delivery dispatch bot system for WhatsApp and Telegram",
     docs_url="/docs",
-    redoc_url="/redoc",
+    redoc_url=None,  # משתמשים ב-endpoint מותאם במקום
     openapi_url="/openapi.json"
 )
 
@@ -82,3 +83,18 @@ async def shutdown() -> None:
 async def health_check() -> dict[str, str]:
     """Health check endpoint"""
     return {"status": "healthy"}
+
+
+@app.get("/redoc", include_in_schema=False)
+async def redoc_html():
+    """
+    ReDoc documentation endpoint עם CDN מותאם.
+
+    משתמש ב-unpkg במקום jsdelivr כדי למנוע בעיות טעינה
+    שגורמות לדף ריק.
+    """
+    return get_redoc_html(
+        openapi_url=app.openapi_url,
+        title=f"{app.title} - ReDoc",
+        redoc_js_url="https://unpkg.com/redoc@latest/bundles/redoc.standalone.js",
+    )


### PR DESCRIPTION
## סיכום
PR זה מתקן את נקודת הקצה (endpoint) של תיעוד ה-ReDoc על ידי מימוש נקודת קצה מותאמת אישית עם CDN חלופי (unpkg), במקום להסתמך על הגדרת ברירת המחדל של FastAPI שגרמה לבעיות בטעינת דף ריק.

## שינויים
- ביטול נקודת הקצה המוגדרת כברירת מחדל של ReDoc ב-FastAPI על ידי הגדרת `redoc_url=None` בקונפיגורציית OpenAPI.
- הוספת נקודת קצה מותאמת אישית ל-`/redoc` המשתמשת במפורש ב-CDN של `unpkg.com` עבור ה-standalone bundle של ReDoc, במקום ב-CDN של jsdelivr המוגדר כברירת מחדל.
- ייבוא הפונקציה `get_redoc_html` מתוך `fastapi.openapi.docs` כדי לבנות בצורה נכונה את תגובת ה-HTML של ReDoc.
- סימון נקודת הקצה המותאמת אישית עם `include_in_schema=False` כדי למנוע את הופעתה בתוך ה-OpenAPI schema.

## פרטי מימוש
נקודת הקצה המותאמת אישית של ReDoc משתמשת בכתובת `https://unpkg.com/redoc@latest/bundles/redoc.standalone.js` כמקור ה-JavaScript, מה שפתר את בעיות הטעינה מה-CDN שגרמו לדף התיעוד להיראות ריק. נקודת הקצה שומרת על אותה פונקציונליות כמו ברירת המחדל של ReDoc תוך שהיא מספקת אמינות גבוהה יותר דרך ספק CDN חלופי.


## Summary
This PR fixes the ReDoc documentation endpoint by implementing a custom endpoint with an alternative CDN (unpkg) instead of relying on FastAPI's default configuration, which was causing blank page loading issues.

## Changes
- Disabled FastAPI's default ReDoc endpoint by setting `redoc_url=None` in the OpenAPI configuration
- Added a custom `/redoc` endpoint that explicitly uses `unpkg.com` CDN for the ReDoc standalone bundle instead of the default jsdelivr CDN
- Imported `get_redoc_html` from `fastapi.openapi.docs` to properly construct the ReDoc HTML response
- Marked the custom endpoint with `include_in_schema=False` to prevent it from appearing in the OpenAPI schema

## Implementation Details
The custom ReDoc endpoint uses `https://unpkg.com/redoc@latest/bundles/redoc.standalone.js` as the JavaScript source, which resolves CDN loading issues that were causing the documentation page to render blank. The endpoint maintains the same functionality as the default ReDoc while providing better reliability through the alternative CDN provider.

https://claude.ai/code/session_016TDiJPGehZM9j1GzirwBfk