### PR TITLE
אתר תיעוד עברית

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -12,24 +12,24 @@ from app.api.webhooks.telegram import router as telegram_router
 
 router = APIRouter()
 
-router.include_router(deliveries_router, prefix="/deliveries", tags=["deliveries"])
-router.include_router(users_router, prefix="/users", tags=["users"])
-router.include_router(wallets_router, prefix="/wallets", tags=["wallets"])
-router.include_router(migrations_router, prefix="/migrations", tags=["migrations"])
+router.include_router(deliveries_router, prefix="/deliveries", tags=["Deliveries"])
+router.include_router(users_router, prefix="/users", tags=["Users"])
+router.include_router(wallets_router, prefix="/wallets", tags=["Wallets"])
+router.include_router(migrations_router, prefix="/migrations", tags=["Migrations"])
 # Canonical webhook endpoints (documented)
-router.include_router(whatsapp_router, prefix="/whatsapp", tags=["webhooks"])
-router.include_router(telegram_router, prefix="/telegram", tags=["webhooks"])
+router.include_router(whatsapp_router, prefix="/whatsapp", tags=["Webhooks"])
+router.include_router(telegram_router, prefix="/telegram", tags=["Webhooks"])
 
 # Backwards-compatible webhook endpoints
 router.include_router(
     whatsapp_router,
     prefix="/webhooks/whatsapp",
-    tags=["webhooks"],
+    tags=["Webhooks"],
     include_in_schema=False
 )
 router.include_router(
     telegram_router,
     prefix="/webhooks/telegram",
-    tags=["webhooks"],
+    tags=["Webhooks"],
     include_in_schema=False
 )

--- a/app/api/routes/migrations.py
+++ b/app/api/routes/migrations.py
@@ -10,7 +10,12 @@ from app.db.database import get_db
 router = APIRouter()
 
 
-@router.api_route("/run-migration-001", methods=["GET", "POST"])
+@router.api_route(
+    "/run-migration-001",
+    methods=["GET", "POST"],
+    summary="הרצת מיגרציה 001 (שדות הרשמת שליחים)",
+    description="מוסיף שדות הרשמת שליחים לטבלת users. בטוח להריץ מספר פעמים (משתמש ב-IF NOT EXISTS).",
+)
 async def run_courier_fields_migration(
     db: AsyncSession = Depends(get_db)
 ):

--- a/app/api/routes/users.py
+++ b/app/api/routes/users.py
@@ -104,7 +104,17 @@ class UserResponse(BaseModel):
         return v.name
 
 
-@router.post("/", response_model=UserResponse)
+@router.post(
+    "/",
+    response_model=UserResponse,
+    summary="יצירת משתמש חדש",
+    description="יצירת משתמש חדש במערכת (בדרך כלל נקרא אוטומטית ע\"י webhook-ים).",
+    responses={
+        200: {"description": "המשתמש נוצר בהצלחה"},
+        400: {"description": "המשתמש כבר קיים"},
+        422: {"description": "שגיאת ולידציה בנתוני הבקשה"},
+    },
+)
 async def create_user(
     user_data: UserCreate,
     db: AsyncSession = Depends(get_db)
@@ -125,7 +135,13 @@ async def create_user(
     return user
 
 
-@router.get("/{user_id}", response_model=UserResponse)
+@router.get(
+    "/{user_id}",
+    response_model=UserResponse,
+    summary="קבלת משתמש לפי מזהה",
+    description="מחזיר משתמש לפי מזהה (ID).",
+    responses={200: {"description": "המשתמש נמצא"}, 404: {"description": "המשתמש לא נמצא"}},
+)
 async def get_user(
     user_id: int,
     db: AsyncSession = Depends(get_db)
@@ -138,7 +154,13 @@ async def get_user(
     return user
 
 
-@router.get("/phone/{phone_number}", response_model=UserResponse)
+@router.get(
+    "/phone/{phone_number}",
+    response_model=UserResponse,
+    summary="קבלת משתמש לפי מספר טלפון",
+    description="מחזיר משתמש לפי מספר טלפון (כפי שנשמר במערכת).",
+    responses={200: {"description": "המשתמש נמצא"}, 404: {"description": "המשתמש לא נמצא"}},
+)
 async def get_user_by_phone(
     phone_number: str,
     db: AsyncSession = Depends(get_db)
@@ -153,7 +175,12 @@ async def get_user_by_phone(
     return user
 
 
-@router.get("/couriers/", response_model=List[UserResponse])
+@router.get(
+    "/couriers/",
+    response_model=List[UserResponse],
+    summary="קבלת כל השליחים הפעילים",
+    description="מחזיר רשימה של כל המשתמשים עם role=COURIER ו-is_active=true.",
+)
 async def get_couriers(db: AsyncSession = Depends(get_db)):
     """Get all active couriers"""
     result = await db.execute(
@@ -165,7 +192,16 @@ async def get_couriers(db: AsyncSession = Depends(get_db)):
     return list(result.scalars().all())
 
 
-@router.patch("/{user_id}", response_model=UserResponse)
+@router.patch(
+    "/{user_id}",
+    response_model=UserResponse,
+    summary="עדכון משתמש",
+    description=(
+        "עדכון פרטי משתמש. תומך גם ב-query parameters (לתאימות לאחור) וגם ב-request body (מומלץ). "
+        "אם שניהם נשלחים, ה-request body גובר."
+    ),
+    responses={200: {"description": "המשתמש עודכן"}, 404: {"description": "המשתמש לא נמצא"}},
+)
 async def update_user(
     user_id: int,
     # תמיכה ב-query parameters לתאימות לאחור

--- a/app/api/routes/wallets.py
+++ b/app/api/routes/wallets.py
@@ -32,7 +32,12 @@ class LedgerEntryResponse(BaseModel):
         from_attributes = True
 
 
-@router.get("/{courier_id}", response_model=WalletResponse)
+@router.get(
+    "/{courier_id}",
+    response_model=WalletResponse,
+    summary="קבלת ארנק של שליח",
+    description="מחזיר את הארנק של השליח, או יוצר חדש אם לא קיים.",
+)
 async def get_wallet(
     courier_id: int,
     db: AsyncSession = Depends(get_db)
@@ -43,7 +48,11 @@ async def get_wallet(
     return wallet
 
 
-@router.get("/{courier_id}/balance")
+@router.get(
+    "/{courier_id}/balance",
+    summary="קבלת יתרה נוכחית",
+    description="מחזיר רק את היתרה (balance) של השליח.",
+)
 async def get_balance(
     courier_id: int,
     db: AsyncSession = Depends(get_db)
@@ -54,7 +63,12 @@ async def get_balance(
     return {"courier_id": courier_id, "balance": balance}
 
 
-@router.get("/{courier_id}/history", response_model=List[LedgerEntryResponse])
+@router.get(
+    "/{courier_id}/history",
+    response_model=List[LedgerEntryResponse],
+    summary="קבלת היסטוריית תנועות בארנק",
+    description="מחזיר רשימת תנועות (ledger) עבור שליח, בסדר יורד, עם הגבלת כמות.",
+)
 async def get_transaction_history(
     courier_id: int,
     limit: int = 20,
@@ -66,7 +80,11 @@ async def get_transaction_history(
     return history
 
 
-@router.get("/{courier_id}/can-capture")
+@router.get(
+    "/{courier_id}/can-capture",
+    summary="בדיקה אם שליח יכול לתפוס משלוח",
+    description="בודק האם לשליח יש מספיק אשראי/יתרה לתפיסת משלוח עם עמלה נתונה.",
+)
 async def check_can_capture(
     courier_id: int,
     fee: float = 10.0,

--- a/app/api/webhooks/telegram.py
+++ b/app/api/webhooks/telegram.py
@@ -247,7 +247,14 @@ async def send_welcome_message(chat_id: str):
     await send_telegram_message(chat_id, welcome_text, keyboard, inline=True)
 
 
-@router.post("/webhook")
+@router.post(
+    "/webhook",
+    summary="Webhook - Telegram (קבלת עדכונים נכנסים)",
+    description=(
+        "נקודת כניסה לקבלת עדכונים מ-Telegram Bot API. "
+        "תומכת גם בהודעות טקסט/תמונות וגם ב-callback queries (כפתורים)."
+    ),
+)
 async def telegram_webhook(
     update: TelegramUpdate,
     background_tasks: BackgroundTasks,

--- a/app/api/webhooks/whatsapp.py
+++ b/app/api/webhooks/whatsapp.py
@@ -267,7 +267,14 @@ async def send_welcome_message(phone_number: str):
     await send_whatsapp_message(phone_number, welcome_text, keyboard)
 
 
-@router.post("/webhook")
+@router.post(
+    "/webhook",
+    summary="Webhook - WhatsApp (קבלת הודעות נכנסות)",
+    description=(
+        "נקודת כניסה לקבלת הודעות מ-WhatsApp Gateway. "
+        "מבצעת ניתוב לזרימת שולח/שליח לפי role ומנהלת state machine."
+    ),
+)
 async def whatsapp_webhook(
     payload: WhatsAppWebhookPayload,
     background_tasks: BackgroundTasks,
@@ -539,7 +546,11 @@ async def whatsapp_webhook(
     return {"processed": len(responses), "responses": responses}
 
 
-@router.get("/webhook")
+@router.get(
+    "/webhook",
+    summary="Webhook Verification - WhatsApp",
+    description="אימות webhook (challenge) עבור WhatsApp Business API.",
+)
 async def whatsapp_verify(
     hub_mode: str = None,
     hub_challenge: str = None,

--- a/app/static/swagger-rtl.css
+++ b/app/static/swagger-rtl.css
@@ -1,0 +1,52 @@
+@import url("https://unpkg.com/swagger-ui-dist@5/swagger-ui.css");
+
+/* RTL + Hebrew-friendly defaults for Swagger UI */
+html,
+body {
+  direction: rtl;
+  text-align: right;
+  font-family: system-ui, -apple-system, Segoe UI, Arial, "Noto Sans Hebrew",
+    sans-serif;
+}
+
+/* Keep the topbar layout sane in RTL */
+.swagger-ui .topbar .topbar-wrapper {
+  flex-direction: row-reverse;
+}
+
+/* Operation summary row: put method badge on the right */
+.swagger-ui .opblock .opblock-summary {
+  flex-direction: row-reverse;
+}
+
+/* Parameter and schema tables */
+.swagger-ui table thead tr td,
+.swagger-ui table thead tr th,
+.swagger-ui table tbody tr td,
+.swagger-ui table tbody tr th {
+  text-align: right;
+}
+
+/* Make code blocks still LTR for readability (URLs, JSON, curl, etc.) */
+.swagger-ui pre,
+.swagger-ui code,
+.swagger-ui .curl-command,
+.swagger-ui .microlight {
+  direction: ltr;
+  text-align: left;
+}
+
+/* Inputs should remain LTR (IDs, numbers, URLs) */
+.swagger-ui input,
+.swagger-ui textarea {
+  direction: ltr;
+  text-align: left;
+}
+
+/* Prevent some labels from awkward wrapping */
+.swagger-ui .opblock-summary-description,
+.swagger-ui .opblock-summary-path,
+.swagger-ui .opblock-summary-method {
+  unicode-bidi: plaintext;
+}
+


### PR DESCRIPTION
כן — ובריפו הזה כבר מימשתי את זה בפועל.

מה השתנה בריפו
/docs: הוחלף לעמוד Swagger UI מותאם עם RTL וסטייל “ידידותי לעברית” (CSS משלנו).
/redoc: מוגש כ‑HTML מותאם עם dir="rtl" כדי שתהיה תצוגה ימנית‑לשמאל.
תוכן ה‑OpenAPI (סיכומים/תיאורים): תורגמו לעברית ב‑routes (Deliveries/Users/Wallets/Webhooks/Migrations) + תיאור כללי ותגיות עם תיאורים בעברית.
קבצים עיקריים
app/main.py – הגדרת docs מותאמים + תגיות OpenAPI
app/static/swagger-rtl.css – CSS ל‑RTL עבור Swagger UI
app/api/routes/*.py + app/api/webhooks/*.py – תרגום summary/description
מצב עבודה
כל הטסטים עברו (112/112).
עשיתי commit + push לענף: cursor/-bc-410138b5-19ac-4f2e-ba77-8a82ad086983-786e
הערה קצרה: כפתורי הממשק של Swagger UI עצמם (כמו “Try it out”) עדיין באנגלית, כי זה מגיע מהכלי; מה שתורגם לעברית הוא התוכן (כותרות/תיאורים/תגובות) + RTL. אם תרצה גם תרגום מלא של ה‑UI, אפשר לעשות את זה אבל זה דורש שכבת UI מותאמת יותר (פחות “ברירת מחדל”).





<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds Hebrew language support and RTL layout to the API documentation pages (`/docs` and `/redoc`).

---
<a href="https://cursor.com/background-agent?bcId=bc-410138b5-19ac-4f2e-ba77-8a82ad086983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-410138b5-19ac-4f2e-ba77-8a82ad086983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

