### PR TITLE
fix: ביטול cache של גרסת WhatsApp Web למניעת שגיאת version fallback

### DIFF
--- a/whatsapp_gateway/index.js
+++ b/whatsapp_gateway/index.js
@@ -102,6 +102,9 @@ async function initializeClient() {
         client = await wppconnect.create({
             session: SESSION_NAME,
             autoClose: 0, // Disable auto-close (0 = never)
+            // ביטול cache של גרסת WhatsApp Web — תמיד טוען את הגרסה העדכנית ביותר
+            // מונע שגיאת "Version not available for X, using latest as fallback"
+            webVersionCache: { type: 'none' },
             tokenStore: 'file',
             folderNameToken: SESSION_FOLDER,  // Use absolute path to match disk mount
             catchQR: (base64Qr, asciiQR, attempts, urlCode) => {

--- a/whatsapp_gateway/package.json
+++ b/whatsapp_gateway/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon index.js"
   },
   "dependencies": {
-    "@wppconnect-team/wppconnect": "^1.29.0",
+    "@wppconnect-team/wppconnect": "^1.38.0",
     "express": "^4.18.2",
     "cors": "^2.8.5"
   },


### PR DESCRIPTION
הוספת webVersionCache: { type: 'none' } לאתחול WPPConnect כדי שתמיד ייטען הגרסה העדכנית ביותר של WhatsApp Web ישירות, במקום להסתמך על גרסה שמורה שעלולה להפוך מיושנת ולגרום לשגיאת
"Version not available for X, using latest as fallback". בנוסף, עדכון WPPConnect מ-1.29.0 ל-1.38.0.

https://claude.ai/code/session_012CrBszu5nhXtNV8thTzH8p