### PR TITLE
Claude/fix shipment bot 96 t v xo6

### DIFF
--- a/whatsapp_gateway/package.json
+++ b/whatsapp_gateway/package.json
@@ -8,7 +8,7 @@
     "dev": "nodemon index.js"
   },
   "dependencies": {
-    "@wppconnect-team/wppconnect": "^1.38.0",
+    "@wppconnect-team/wppconnect": "^1.29.0",
     "express": "^4.18.2",
     "cors": "^2.8.5"
   },


### PR DESCRIPTION
:

**הבעיה:** `sendListMessage` מחזיר הצלחה לכתובות `@lid` אבל ההודעה לא מגיעה בפועל — הלקוח לא מקבל את הרשימה האינטראקטיבית.

**שורש הבעיה:** PR #98 (commit `bd2b297`) ביצע שני שינויים שגרמו לשבירה:
1. שדרוג WPPConnect מ-`1.29.0` ל-`1.38.0`
2. הוספת `webVersionCache: { type: 'none' }` שמכריח טעינת הגרסה האחרונה של WhatsApp Web

**התיקון (commit `e1af2a7`):**
1. **חזרה ל-WPPConnect 1.29.0** — הגרסה שעבדה
2. **הסרת `webVersionCache: { type: 'none' }`** — חזרה לברירת המחדל
3. **הסרת ה-`isLid` text fallback** — כתובות `@lid` עוברות עכשיו דרך אותה שרשרת כמו כל כתובת אחרת: `sendButtons` → `sendListMessage` → `sendText`

**חשוב:** אחרי הדיפלוי, צריך להריץ `npm install` בתיקיית הגייטוויי כדי שהדאונגרייד ייכנס לתוקף. אם יש `node_modules` קיים עם גרסה 1.38, צריך למחוק אותו ולהתקין מחדש.