### PR TITLE
fix: כפתור "חזרה לתפריט" בארנק שליח מחזיר לתפריט במקום להציג שוב ארנק…

### DIFF
--- a/app/state_machine/handlers.py
+++ b/app/state_machine/handlers.py
@@ -999,6 +999,10 @@ class CourierStateHandler:
 
     async def _handle_view_wallet(self, user: User, message: str, context: dict, photo_file_id: str):
         """Handle wallet view [3.1]"""
+        # כפתור חזרה לתפריט - מחזיר לתפריט הראשי
+        if "חזרה" in message or "תפריט" in message:
+            return await self._handle_menu(user, "תפריט", context, None)
+
         from app.core.config import settings
 
         response = MessageResponse(

--- a/tests/test_stage_3.py
+++ b/tests/test_stage_3.py
@@ -246,6 +246,75 @@ class TestStage31DriverMenu:
 
 
 # ============================================================================
+# באג #87 - כפתור "חזרה לתפריט" בארנק שליח מציג שוב את הארנק
+# ============================================================================
+
+
+class TestCourierWalletBackButton:
+    """בדיקות לכפתור חזרה לתפריט ממסך הארנק (issue #87)"""
+
+    @pytest.mark.asyncio
+    async def test_back_from_wallet_returns_to_menu(
+        self, db_session, user_factory
+    ):
+        """לחיצה על 'חזרה לתפריט' מארנק מחזירה לתפריט ולא מציגה שוב ארנק"""
+        from app.state_machine.states import CourierState
+
+        courier = await user_factory(
+            phone_number="+972506666666",
+            name="Wallet Tester",
+            role=UserRole.COURIER,
+            platform="telegram",
+            telegram_chat_id="60001",
+            approval_status=ApprovalStatus.APPROVED,
+        )
+
+        handler = CourierStateHandler(db_session, platform="telegram")
+        state_manager = StateManager(db_session)
+        await state_manager.force_state(
+            courier.id, "telegram", CourierState.VIEW_WALLET.value, {}
+        )
+
+        response, new_state = await handler.handle_message(
+            courier, "🔙 חזרה לתפריט", None
+        )
+
+        # חייב לחזור לתפריט - לא להישאר בארנק
+        assert new_state == CourierState.MENU.value
+        assert "תפריט שליח" in response.text
+
+    @pytest.mark.asyncio
+    async def test_wallet_displays_when_no_back_button(
+        self, db_session, user_factory
+    ):
+        """כניסה רגילה לארנק מציגה פרטי ארנק כרגיל"""
+        from app.state_machine.states import CourierState
+
+        courier = await user_factory(
+            phone_number="+972506666667",
+            name="Wallet Viewer",
+            role=UserRole.COURIER,
+            platform="telegram",
+            telegram_chat_id="60002",
+            approval_status=ApprovalStatus.APPROVED,
+        )
+
+        handler = CourierStateHandler(db_session, platform="telegram")
+        state_manager = StateManager(db_session)
+        await state_manager.force_state(
+            courier.id, "telegram", CourierState.MENU.value, {}
+        )
+
+        # נכנסים לארנק דרך התפריט
+        response, new_state = await handler.handle_message(
+            courier, "💰 מצב הארנק", None
+        )
+
+        assert new_state == CourierState.VIEW_WALLET.value
+        assert "פרטי הארנק" in response.text
+
+
+# ============================================================================
 # שלב 3.2 - תפריט סדרן היברידי - Handlers
 # ============================================================================
 


### PR DESCRIPTION
… (#87)

_handle_view_wallet לא בדק כלל אם המשתמש לחץ "חזרה" - תמיד הציג את פרטי הארנק מחדש. הוספת guard ל-"חזרה"/"תפריט" בדומה לשאר ה-handlers (deposit_request, deposit_upload, change_area).

הסתיים. הנה סיכום:

## סיכום - תיקון באג #87

**הבעיה:** לחיצה על "🔙 חזרה לתפריט" ממסך הארנק של שליח הציגה שוב את פרטי הארנק במקום לחזור לתפריט.

**שורש הבעיה:** `_handle_view_wallet` ב-`handlers.py:1000` לא בדק כלל את תוכן ההודעה — תמיד הציג את הארנק מחדש והחזיר `CourierState.VIEW_WALLET`. בנוסף, ב-`telegram.py:631` הבדיקה ל-"חזרה לתפריט" מדלגת על שליחים (`user.role not in (UserRole.COURIER, ...)`), כך שההודעה נפלה ל-state handler שלא טיפל בה.

**התיקון:** הוספת guard ב-`_handle_view_wallet` (שורה 1002-1003) שבודק `"חזרה" in message or "תפריט" in message` ומנתב חזרה ל-`_handle_menu` — בדיוק כמו שכבר נעשה ב-`_handle_deposit_request`, `_handle_deposit_upload` ו-`_handle_change_area`.

**קבצים שהשתנו:**
- `app/state_machine/handlers.py` — 4 שורות חדשות (guard + הערה)
- `tests/test_stage_3.py` — 69 שורות חדשות (2 בדיקות)

**בדיקות:** כל 238 הבדיקות עוברות (כולל 2 חדשות).

הקוד נדחף ל-branch `claude/handle-issue-87-2mrgA`. לא הצלחתי ליצור PR דרך CLI (gh לא מותקן), אבל תוכל ליצור אחד דרך הלינק:
https://github.com/amirbiron/Shipment-bot/pull/new/claude/handle-issue-87-2mrgA



https://claude.ai/code/session_01X33skVsoLJFroDds99C734