### PR TITLE
hotfix: החזרת backwards-compatible route לגטוויי בפרודקשן

### DIFF
--- a/app/api/routes/__init__.py
+++ b/app/api/routes/__init__.py
@@ -21,3 +21,9 @@ router.include_router(migrations_router, prefix="/migrations", tags=["Migrations
 # Webhook endpoints
 router.include_router(whatsapp_router, prefix="/whatsapp", tags=["Webhooks"])
 router.include_router(telegram_router, prefix="/telegram", tags=["Webhooks"])
+# Backwards-compatible — הגטוויי בפרודקשן עדיין שולח ל-URL הישן
+# TODO: להסיר אחרי שהגטוויי יתעדכן ל-/api/whatsapp/webhook
+router.include_router(
+    whatsapp_router, prefix="/webhooks/whatsapp", tags=["Webhooks (Legacy)"],
+    deprecated=True,
+)


### PR DESCRIPTION
הגטוויי בפרודקשן עדיין שולח ל-/api/webhooks/whatsapp/webhook (URL ישן). הסרת ה-route ב-PR גרמה ל-404 על כל הודעה נכנסת.

נוסף route legacy (deprecated) שמפנה לאותו handler — ללא שכפול קוד. TODO: להסיר אחרי עדכון הגטוויי.

https://claude.ai/code/session_01N1HxiVeUcfWcbn2wKH1Lwh