### PR TITLE
fix: תיקון מיגרציה 003 - ALTER TYPE ADD VALUE לא יכול לרוץ בתוך בלוק …

### DIFF
--- a/app/db/migrations.py
+++ b/app/db/migrations.py
@@ -165,14 +165,11 @@ async def run_migration_003(conn: AsyncConnection) -> None:
     """))
 
     # עדכון enum של UserRole - הוספת station_owner
-    # הערה: ALTER TYPE ... ADD VALUE הוא idempotent ב-PG 12+
-    await conn.execute(text("""
-        DO $$ BEGIN
-            ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'station_owner';
-        EXCEPTION
-            WHEN duplicate_object THEN null;
-        END $$;
-    """))
+    # הערה: ALTER TYPE ... ADD VALUE לא ניתן להרצה בתוך בלוק DO/PL/pgSQL,
+    # לכן מריצים כ-statement רגיל. IF NOT EXISTS דורש PG 12+.
+    await conn.execute(text(
+        "ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'station_owner'"
+    ))
 
 
 async def run_migration_004(conn: AsyncConnection) -> None:


### PR DESCRIPTION
## סיכום

נמצאו **שני באגים** שמנעו יצירת תחנה ונגישות לפאנל ניהול:

### באג 1: מיגרציה שבורה (שורש הבעיה - ה-500)
`app/db/migrations.py:169-175` — הפקודה `ALTER TYPE userrole ADD VALUE 'station_owner'` הייתה עטופה בבלוק `DO $$ ... END $$` (PL/pgSQL). **PostgreSQL לא מאפשר `ALTER TYPE ... ADD VALUE` בתוך PL/pgSQL** — החריגה נתפסה בשקט, הערך `station_owner` מעולם לא נוסף ל-enum, וכל ניסיון לעדכן תפקיד ל-`STATION_OWNER` זרק 500.

**תיקון:** הוצאתי את הפקודה מבלוק ה-DO והרצתי אותה כ-statement רגיל.

### באג 2: עדכון תפקיד לא אטומי
`app/api/routes/stations.py` — יצירת התחנה ועדכון הרול היו שני commits נפרדים. אם הראשון הצליח והשני נכשל, המשתמש נתקע עם תחנה אבל בלי תפקיד `STATION_OWNER`.

**תיקון:** commit אחד אטומי + recovery כשהתחנה קיימת אבל הרול שגוי.

### מה לעשות עכשיו
לאחר ה-deploy, המיגרציה תרוץ אוטומטית ב-startup. לחלופין, אפשר להריץ ידנית:
```
POST /api/migrations/run-migration-003
```


@…DO/PL/pgSQL

הבעיה: הפקודה ALTER TYPE userrole ADD VALUE 'station_owner' הייתה עטופה בבלוק DO $$ ... END $$ (PL/pgSQL). PostgreSQL לא מאפשר ALTER TYPE ... ADD VALUE בתוך PL/pgSQL — החריגה נתפסה בשקט והערך station_owner מעולם לא נוסף ל-enum, מה שגרם ל-500 ביצירת תחנה.

שינויים:
- migrations.py: הוצאת ALTER TYPE מבלוק DO, הרצה כ-statement רגיל
- routes/migrations.py: הוספת endpoint להרצת migration_003 ידנית



https://claude.ai/code/session_01HEEc2XCWSEULVsDonvnqVg