### PR TITLE
fix: תיקון case mismatch ב-enum — STATION_OWNER במקום station_owner

### DIFF
--- a/app/db/migrations.py
+++ b/app/db/migrations.py
@@ -238,10 +238,12 @@ async def add_enum_values(engine: AsyncEngine) -> None:
     """
     async with engine.connect() as conn:
         await conn.execution_options(isolation_level="AUTOCOMMIT")
+        # SQLEnum(UserRole) ללא values_callable שולח את שם ה-member (STATION_OWNER)
+        # ולא את ה-value (station_owner), לכן חייבים להוסיף באותיות גדולות.
         await conn.execute(text(
-            "ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'station_owner'"
+            "ALTER TYPE userrole ADD VALUE IF NOT EXISTS 'STATION_OWNER'"
         ))
-        logger.info("Ensured 'station_owner' exists in userrole enum")
+        logger.info("Ensured 'STATION_OWNER' exists in userrole enum")
 
 
 async def run_all_migrations(conn: AsyncConnection) -> None:


### PR DESCRIPTION
הבעיה הייתה פשוטה ברגע שקראתי את הלוג בעיון:

- `SQLEnum(UserRole)` **ללא** `values_callable` → SQLAlchemy שולח את **שם ה-member**: `SENDER`, `COURIER`, `ADMIN`, `STATION_OWNER`
- `SQLEnum(ApprovalStatus, values_callable=...)` **עם** `values_callable` → שולח את **הערך**: `pending`, `approved`, `rejected`
- המיגרציה הוסיפה `'station_owner'` (lowercase) → PG לא מזהה את `'STATION_OWNER'` (uppercase) ששולח SQLAlchemy

התיקון: שינוי המיגרציה ל-`'STATION_OWNER'` באותיות גדולות, כמו שאר ערכי ה-enum בDB (`SENDER`, `COURIER`, `ADMIN`).


SQLEnum(UserRole) ללא values_callable שולח את שם ה-member (STATION_OWNER) ולא את ה-value (station_owner). המיגרציה הוסיפה 'station_owner' באותיות קטנות, אבל PG קיבל 'STATION_OWNER' באותיות גדולות — ולכן דחה את הערך.

https://claude.ai/code/session_01HEEc2XCWSEULVsDonvnqVg