### PR TITLE
תיקון: הוספת מיגרציה 008 ליצירת עמודת rejection_note בטבלת users

### DIFF
--- a/app/db/migrations.py
+++ b/app/db/migrations.py
@@ -317,6 +317,14 @@ async def run_migration_007(conn: AsyncConnection) -> None:
     """))
 
 
+async def run_migration_008(conn: AsyncConnection) -> None:
+    """מיגרציה 008 - הוספת עמודת rejection_note לטבלת users (הערת דחייה מהמנהל)."""
+    await conn.execute(text("""
+        ALTER TABLE users
+            ADD COLUMN IF NOT EXISTS rejection_note TEXT;
+    """))
+
+
 async def run_all_migrations(conn: AsyncConnection) -> None:
     """הרצת כל המיגרציות ברצף (ללא ALTER TYPE — ראה add_enum_values)."""
     logger.info("Running migration 001...")
@@ -333,3 +341,5 @@ async def run_all_migrations(conn: AsyncConnection) -> None:
     await run_migration_006(conn)
     logger.info("Running migration 007...")
     await run_migration_007(conn)
+    logger.info("Running migration 008...")
+    await run_migration_008(conn)


### PR DESCRIPTION


## סיכום

**הבעיה:** בוט הוואטסאפ לא הגיב כלל להודעות. בכל פנייה ל-API נזרקה שגיאה:
```
column users.rejection_note does not exist
```

**הסיבה:** העמודה `rejection_note` הוגדרה במודל SQLAlchemy (`app/db/models/user.py:61`) עם הערה שמצביעה על מיגרציה נדרשת, אבל המיגרציה בפועל מעולם לא נוספה ל-`app/db/migrations.py`. מכיוון ש-`Base.metadata.create_all` לא מוסיפה עמודות חדשות לטבלאות קיימות, העמודה לא נוצרה ב-DB.

**התיקון:** הוספת `run_migration_008` ב-`app/db/migrations.py:320` שמריצה:
```sql
ALTER TABLE users ADD COLUMN IF NOT EXISTS rejection_note TEXT;
```
המיגרציה idempotent ותרוץ אוטומטית בעליית השרת הבאה. לאחר הדיפלוי הבוט יחזור לפעולה תקינה.


העמודה הוגדרה במודל SQLAlchemy אבל חסרה מיגרציה בפועל, מה שגרם לשגיאת "column users.rejection_note does not exist" בכל שאילתת SELECT על טבלת users וחסם את הבוט מלהגיב.

https://claude.ai/code/session_01ShPi949Px1SHcppgq5oqP9


