### PR TITLE
תיקון: שדרוג psycopg2-binary ל-2.9.10 לתמיכה ב-Python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-multipart==0.0.6
 # Database
 sqlalchemy[asyncio]==2.0.36
 asyncpg==0.31.0
-psycopg2-binary==2.9.9  # For sync migrations
+psycopg2-binary==2.9.10  # For sync migrations
 alembic==1.13.1
 
 # Configuration


### PR DESCRIPTION
Render שדרגו את גרסת Python ל-3.13, וגרסה 2.9.9 של psycopg2-binary לא תומכת בה (הסימבול _PyInterpreterState_Get הוסר ב-3.13). גרסה 2.9.10 מוסיפה תמיכה ב-Python 3.13.

https://claude.ai/code/session_01HZgETDaCUB3ebQji4pjCGL

<!--
תבנית PR לפרויקט Shipment Bot.
חובה למלא בעברית — כותרת, תיאור, סיכום, הכל בעברית.
ראו CLAUDE.md > "כללים כלליים" ו-"צ'קליסט לפני PR".
-->

## תיאור קצר
<!-- מה שיניתם ולמה? 2-3 משפטים -->


## שינויים עיקריים
<!-- סמנו את התחומים הרלוונטיים ופרטו -->
- [ ] קוד (Backend / Services)
- [ ] בוט טלגרם
- [ ] בוט וואטסאפ
- [ ] מכונת מצבים (State Machine)
- [ ] מסד נתונים / מיגרציות
- [ ] Celery / Workers
- [ ] תיעוד
- [ ] DevOps / CI/CD

פירוט:
-
-

## בדיקות
<!-- איך בדקתם? מה עבר? מה נשאר? -->
- [ ] Unit tests — עוברים
- [ ] בדיקות ידניות
- [ ] כיסוי ל-edge cases

## CI Checks
- ולידציית דיאגרמות (`--check`)
- pytest

## סוג שינוי
- [ ] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית / CI
- [ ] breaking change: שינוי שובר תאימות

## צ'קליסט
<!-- מבוסס על CLAUDE.md > "צ'קליסט לפני PR" ו-"אסור!" -->
- [ ] כל הפלט בעברית (כותרת PR, תיאור, הודעות commit, הערות בקוד)
- [ ] אין `print()` — רק `logger`
- [ ] מספרי טלפון מוסתרים בלוגים (`PhoneNumberValidator.mask()`)
- [ ] כל קלט עובר ולידציה
- [ ] קריאות API חיצוני עם Circuit Breaker
- [ ] type hints בכל פונקציה
- [ ] endpoints עם תיעוד OpenAPI
- [ ] בדיקות לפיצ'רים חדשים
- [ ] אין `except Exception: pass`
- [ ] בדיקת authorization לפני כל פעולה
- [ ] ולידציית סטטוס לפני מעבר סטטוס
- [ ] אין N+1 queries
- [ ] בדיקת concurrency — מה קורה בפעולה מקבילית?
- [ ] הודעות שגיאה ברורות בעברית למשתמש
- [ ] מספיק לוגים לדיבאג בפרודקשן
- [ ] אם דו-פלטפורמי — עובד זהה בטלגרם ובוואטסאפ

## השפעות / סיכונים
<!-- השפעה על פרודקשן, ביצועים, אבטחה? תוכנית rollback? -->


## קישורים
- Issue: #
