### PR TITLE
תיקון: הפעלת pgcrypto extension לפני שימוש ב-gen_random_bytes

### DIFF
--- a/migrations/001_add_delivery_token.sql
+++ b/migrations/001_add_delivery_token.sql
@@ -2,6 +2,9 @@
 -- Date: 2026-01-29
 -- Description: Adds a unique token for smart links (prevents ID guessing)
 
+-- Step 0: Enable pgcrypto extension (needed for gen_random_bytes)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
 -- Step 1: Add the column (nullable first for existing rows)
 ALTER TABLE deliveries
 ADD COLUMN IF NOT EXISTS token VARCHAR(32);


### PR DESCRIPTION
המיגרציה 001_add_delivery_token.sql משתמשת ב-gen_random_bytes() שדורש את ה-extension pgcrypto. ב-Render הוא לא מופעל כברירת מחדל, אז מוסיפים CREATE EXTENSION IF NOT EXISTS pgcrypto בתחילת המיגרציה.

https://claude.ai/code/session_01HZgETDaCUB3ebQji4pjCGL

<!--