### PR TITLE
הוספת JWT_SECRET_KEY ל-render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -35,6 +35,8 @@ services:
         sync: false  # Set manually in dashboard
       - key: WHATSAPP_GATEWAY_URL
         value: "https://shipment-bot-wa-gateway-6uqm.onrender.com"
+      - key: JWT_SECRET_KEY
+        sync: false  # Set manually in dashboard — openssl rand -hex 32
     autoDeploy: true
 
   # =====================================================


### PR DESCRIPTION
משתנה סביבה חיוני לפאנל הווב שהיה חסר מהבלופרינט.
מוגדר כ-sync:false כדי שיוגדר ידנית בדשבורד (secret).

https://claude.ai/code/session_01HZgETDaCUB3ebQji4pjCGL


הוספתי `JWT_SECRET_KEY` ל-`render.yaml`. עכשיו צריך להגדיר את הערך ב-Render Dashboard:

1. לך ל-**shipment-bot-api** → Environment
2. הוסף `JWT_SECRET_KEY` עם ערך שנוצר מ:
   ```
   openssl rand -hex 32
   ```
3. Save Changes

זהו — ה-OTP יעבוד אחרי ה-restart. אגב, זו בדיוק הבעיה שדיברנו עליה קודם — health endpoint מורחב שבודק את כל ה-dependencies היה תופס את שני הבאגים האלה (gateway URL שגוי + JWT חסר) ברגע שהשירות עלה.