### PR TITLE
feat: הוסף Liveness ו-Readiness probes לבדיקת בריאות

### DIFF
--- a/app/domain/services/health_service.py
+++ b/app/domain/services/health_service.py
@@ -1,0 +1,109 @@
+"""
+שירות בדיקת בריאות — בדיקות תלויות (DB, Redis, WhatsApp Gateway, Celery).
+
+מספק שתי רמות בדיקה:
+- liveness: האם התהליך חי (ללא בדיקת תלויות)
+- readiness: בדיקה מקיפה של כל התלויות החיצוניות
+"""
+from typing import Any
+
+import httpx
+import redis.asyncio as aioredis
+from sqlalchemy import text
+
+from app.core.config import settings
+from app.core.logging import get_logger
+from app.core.redis_client import get_redis
+from app.db.database import AsyncSessionLocal
+
+logger = get_logger(__name__)
+
+# סטטוסים אפשריים לתשובת readiness
+_STATUS_HEALTHY = "healthy"
+_STATUS_DEGRADED = "degraded"
+
+_CHECK_OK = "ok"
+
+
+async def _check_db() -> str:
+    """בדיקת חיבור למסד הנתונים באמצעות שאילתה קלה."""
+    try:
+        async with AsyncSessionLocal() as session:
+            await session.execute(text("SELECT 1"))
+        return _CHECK_OK
+    except Exception as e:
+        logger.warning("בדיקת בריאות DB נכשלה", extra_data={"error": str(e)})
+        return f"error: {e}"
+
+
+async def _check_redis() -> str:
+    """בדיקת חיבור ל-Redis באמצעות PING."""
+    try:
+        client = await get_redis()
+        await client.ping()
+        return _CHECK_OK
+    except Exception as e:
+        logger.warning("בדיקת בריאות Redis נכשלה", extra_data={"error": str(e)})
+        return f"error: {e}"
+
+
+async def _check_whatsapp_gateway() -> str:
+    """בדיקת זמינות WhatsApp Gateway באמצעות בקשת HTTP."""
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(f"{settings.WHATSAPP_GATEWAY_URL}/health")
+            if response.status_code == 200:
+                return _CHECK_OK
+            return f"error: {response.status_code}"
+    except Exception as e:
+        logger.warning(
+            "בדיקת בריאות WhatsApp Gateway נכשלה",
+            extra_data={"error": str(e)},
+        )
+        return f"error: {e}"
+
+
+async def _check_celery() -> str:
+    """בדיקת זמינות Celery workers באמצעות ping ל-broker (Redis)."""
+    try:
+        client = aioredis.from_url(settings.CELERY_BROKER_URL, decode_responses=True)
+        try:
+            await client.ping()
+            return _CHECK_OK
+        finally:
+            await client.aclose()
+    except Exception as e:
+        logger.warning("בדיקת בריאות Celery נכשלה", extra_data={"error": str(e)})
+        return f"error: {e}"
+
+
+async def check_readiness() -> dict[str, Any]:
+    """
+    בדיקת מוכנות מקיפה — בודק את כל התלויות החיצוניות.
+
+    מחזיר dict עם סטטוס כללי ופירוט לכל תלות:
+    - status: "healthy" אם הכל תקין, "degraded" אם יש בעיה באחת התלויות
+    - db / redis / whatsapp_gateway / celery: "ok" או "error: ..."
+    """
+    db_status = await _check_db()
+    redis_status = await _check_redis()
+    whatsapp_status = await _check_whatsapp_gateway()
+    celery_status = await _check_celery()
+
+    checks = {
+        "db": db_status,
+        "redis": redis_status,
+        "whatsapp_gateway": whatsapp_status,
+        "celery": celery_status,
+    }
+
+    all_ok = all(v == _CHECK_OK for v in checks.values())
+    overall_status = _STATUS_HEALTHY if all_ok else _STATUS_DEGRADED
+
+    if not all_ok:
+        logger.warning(
+            "בדיקת מוכנות — המערכת במצב degraded",
+            extra_data=checks,
+        )
+
+    return {"status": overall_status, **checks}

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -1,0 +1,333 @@
+"""
+בדיקות יחידה ל-Health Check endpoints — liveness ו-readiness.
+"""
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import httpx
+
+
+# ============================================================================
+# Liveness Probe — GET /health
+# ============================================================================
+
+
+class TestLivenessProbe:
+    """בדיקות ל-endpoint /health (liveness probe)."""
+
+    @pytest.mark.unit
+    async def test_liveness_returns_healthy(self, test_client: httpx.AsyncClient) -> None:
+        """liveness probe מחזיר status=healthy תמיד."""
+        response = await test_client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "healthy"}
+
+
+# ============================================================================
+# Readiness Probe — GET /health/ready
+# ============================================================================
+
+
+class TestReadinessProbe:
+    """בדיקות ל-endpoint /health/ready (readiness probe)."""
+
+    @pytest.mark.unit
+    async def test_readiness_all_healthy(self, test_client: httpx.AsyncClient) -> None:
+        """כשכל התלויות תקינות — status=healthy ו-HTTP 200."""
+        with patch(
+            "app.domain.services.health_service._check_db",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_redis",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_whatsapp_gateway",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_celery",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ):
+            response = await test_client.get("/health/ready")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert data["db"] == "ok"
+        assert data["redis"] == "ok"
+        assert data["whatsapp_gateway"] == "ok"
+        assert data["celery"] == "ok"
+
+    @pytest.mark.unit
+    async def test_readiness_db_down(self, test_client: httpx.AsyncClient) -> None:
+        """כש-DB לא זמין — status=degraded ו-HTTP 503."""
+        with patch(
+            "app.domain.services.health_service._check_db",
+            new_callable=AsyncMock,
+            return_value="error: connection refused",
+        ), patch(
+            "app.domain.services.health_service._check_redis",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_whatsapp_gateway",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_celery",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ):
+            response = await test_client.get("/health/ready")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert "error" in data["db"]
+        assert data["redis"] == "ok"
+
+    @pytest.mark.unit
+    async def test_readiness_whatsapp_gateway_down(
+        self, test_client: httpx.AsyncClient
+    ) -> None:
+        """כש-WhatsApp Gateway מחזיר 404 — status=degraded ו-HTTP 503."""
+        with patch(
+            "app.domain.services.health_service._check_db",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_redis",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_whatsapp_gateway",
+            new_callable=AsyncMock,
+            return_value="error: 404",
+        ), patch(
+            "app.domain.services.health_service._check_celery",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ):
+            response = await test_client.get("/health/ready")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert data["whatsapp_gateway"] == "error: 404"
+        assert data["db"] == "ok"
+
+    @pytest.mark.unit
+    async def test_readiness_multiple_failures(
+        self, test_client: httpx.AsyncClient
+    ) -> None:
+        """כשכמה תלויות נכשלות — status=degraded ופירוט לכל תלות."""
+        with patch(
+            "app.domain.services.health_service._check_db",
+            new_callable=AsyncMock,
+            return_value="error: timeout",
+        ), patch(
+            "app.domain.services.health_service._check_redis",
+            new_callable=AsyncMock,
+            return_value="error: connection refused",
+        ), patch(
+            "app.domain.services.health_service._check_whatsapp_gateway",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_celery",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ):
+            response = await test_client.get("/health/ready")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert "error" in data["db"]
+        assert "error" in data["redis"]
+        assert data["whatsapp_gateway"] == "ok"
+        assert data["celery"] == "ok"
+
+    @pytest.mark.unit
+    async def test_readiness_celery_broker_down(
+        self, test_client: httpx.AsyncClient
+    ) -> None:
+        """כש-Celery broker לא זמין — status=degraded."""
+        with patch(
+            "app.domain.services.health_service._check_db",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_redis",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_whatsapp_gateway",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_celery",
+            new_callable=AsyncMock,
+            return_value="error: connection refused",
+        ):
+            response = await test_client.get("/health/ready")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "degraded"
+        assert "error" in data["celery"]
+
+
+# ============================================================================
+# בדיקות יחידה לפונקציות בדיקה פנימיות
+# ============================================================================
+
+
+class TestHealthCheckFunctions:
+    """בדיקות ישירות לפונקציות הבדיקה בשירות."""
+
+    @pytest.mark.unit
+    async def test_check_db_success(self) -> None:
+        """_check_db מחזיר ok כש-DB זמין."""
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "app.domain.services.health_service.AsyncSessionLocal",
+            return_value=mock_session,
+        ):
+            from app.domain.services.health_service import _check_db
+            result = await _check_db()
+
+        assert result == "ok"
+
+    @pytest.mark.unit
+    async def test_check_db_failure(self) -> None:
+        """_check_db מחזיר error כש-DB לא זמין."""
+        mock_session = AsyncMock()
+        mock_session.execute = AsyncMock(side_effect=ConnectionError("refused"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+
+        with patch(
+            "app.domain.services.health_service.AsyncSessionLocal",
+            return_value=mock_session,
+        ):
+            from app.domain.services.health_service import _check_db
+            result = await _check_db()
+
+        assert result.startswith("error:")
+
+    @pytest.mark.unit
+    async def test_check_redis_success(self) -> None:
+        """_check_redis מחזיר ok כש-Redis זמין."""
+        mock_redis = AsyncMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+
+        with patch(
+            "app.domain.services.health_service.get_redis",
+            new_callable=AsyncMock,
+            return_value=mock_redis,
+        ):
+            from app.domain.services.health_service import _check_redis
+            result = await _check_redis()
+
+        assert result == "ok"
+
+    @pytest.mark.unit
+    async def test_check_redis_failure(self) -> None:
+        """_check_redis מחזיר error כש-Redis לא זמין."""
+        with patch(
+            "app.domain.services.health_service.get_redis",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("refused"),
+        ):
+            from app.domain.services.health_service import _check_redis
+            result = await _check_redis()
+
+        assert result.startswith("error:")
+
+    @pytest.mark.unit
+    async def test_check_whatsapp_gateway_success(self) -> None:
+        """_check_whatsapp_gateway מחזיר ok כש-Gateway זמין."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("app.domain.services.health_service.httpx.AsyncClient", return_value=mock_client):
+            from app.domain.services.health_service import _check_whatsapp_gateway
+            result = await _check_whatsapp_gateway()
+
+        assert result == "ok"
+
+    @pytest.mark.unit
+    async def test_check_whatsapp_gateway_404(self) -> None:
+        """_check_whatsapp_gateway מחזיר error: 404 כש-Gateway מחזיר 404."""
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("app.domain.services.health_service.httpx.AsyncClient", return_value=mock_client):
+            from app.domain.services.health_service import _check_whatsapp_gateway
+            result = await _check_whatsapp_gateway()
+
+        assert result == "error: 404"
+
+    @pytest.mark.unit
+    async def test_check_whatsapp_gateway_connection_error(self) -> None:
+        """_check_whatsapp_gateway מחזיר error כשאין חיבור ל-Gateway."""
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("app.domain.services.health_service.httpx.AsyncClient", return_value=mock_client):
+            from app.domain.services.health_service import _check_whatsapp_gateway
+            result = await _check_whatsapp_gateway()
+
+        assert result.startswith("error:")
+
+    @pytest.mark.unit
+    async def test_check_celery_success(self) -> None:
+        """_check_celery מחזיר ok כש-Celery broker זמין."""
+        mock_client = AsyncMock()
+        mock_client.ping = AsyncMock(return_value=True)
+        mock_client.aclose = AsyncMock()
+
+        with patch(
+            "app.domain.services.health_service.aioredis.from_url",
+            return_value=mock_client,
+        ):
+            from app.domain.services.health_service import _check_celery
+            result = await _check_celery()
+
+        assert result == "ok"
+
+    @pytest.mark.unit
+    async def test_check_celery_failure(self) -> None:
+        """_check_celery מחזיר error כש-Celery broker לא זמין."""
+        mock_client = AsyncMock()
+        mock_client.ping = AsyncMock(side_effect=ConnectionError("refused"))
+        mock_client.aclose = AsyncMock()
+
+        with patch(
+            "app.domain.services.health_service.aioredis.from_url",
+            return_value=mock_client,
+        ):
+            from app.domain.services.health_service import _check_celery
+            result = await _check_celery()
+
+        assert result.startswith("error:")


### PR DESCRIPTION
## תיאור קצר
הוספת שתי endpoints לבדיקת בריאות המערכת:
- **Liveness Probe** (`GET /health`) — בדיקה קלה שהתהליך חי, ללא בדיקת תלויות
- **Readiness Probe** (`GET /health/ready`) — בדיקה מקיפה של כל התלויות (DB, Redis, WhatsApp Gateway, Celery)

זה מאפשר ל-Render/Load Balancer להחליט בחכמה מתי לעשות restart (רק אם התהליך מת, לא בגלל כשלון זמני של תלות).

## שינויים עיקריים
- [x] קוד (Backend / Services)
- [x] תיעוד

**פירוט:**
- יצירת `app/domain/services/health_service.py` עם:
  - `_check_db()` — בדיקת חיבור למסד הנתונים
  - `_check_redis()` — בדיקת חיבור ל-Redis
  - `_check_whatsapp_gateway()` — בדיקת זמינות WhatsApp Gateway
  - `_check_celery()` — בדיקת זמינות Celery broker
  - `check_readiness()` — פונקציה מרכזית שמחזירה סטטוס כללי ופירוט לכל תלות

- עדכון `app/main.py`:
  - שינוי `/health` להיות liveness probe פשוט (ללא בדיקות)
  - הוספת `/health/ready` כ-readiness probe עם בדיקות מקיפות
  - תיעוד OpenAPI מלא עם דוגמאות לתשובות 200 ו-503

- יצירת `tests/test_health_check.py` עם 15 unit tests:
  - בדיקות ל-endpoints (liveness, readiness בתרחישים שונים)
  - בדיקות ישירות לכל פונקציית בדיקה (success/failure cases)

## בדיקות
- [x] Unit tests — 15 בדיקות חדשות, כולן עוברות
- [x] כיסוי ל-edge cases:
  - כל התלויות תקינות → HTTP 200, status=healthy
  - תלות אחת נכשלת → HTTP 503, status=degraded
  - מספר תלויות נכשלות → HTTP 503 עם פירוט לכל תלות
  - כל סוג כשלון: connection error, timeout, HTTP error codes

## CI Checks
- pytest — כל 15 הבדיקות עוברות

## סוג שינוי
- [x] feat: פיצ'ר חדש

## צ'קליסט
- [x] כל הפלט בעברית (כותרת, תיאור, הערות בקוד, הודעות logger)
- [x] אין `print()` — רק `logger.warning()`
- [x] type hints בכל פונקציה (`async def ... -> str:`, `-> dict[str, Any]:`)
- [x] endpoints עם תיעוד OpenAPI מלא (summary, description, responses עם דוגמאות)
- [x] בדיקות לפיצ'ר חדש (15 unit tests)
- [x] אין `except Exception: pass`

https://claude.ai/code/session_01DQQ3EWv9z1G8g67w82SbcU