### PR TITLE
תיקון: הוספת privateServiceName לשירותים ב-render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,7 @@ services:
     runtime: python
     region: frankfurt
     plan: starter  # upgrade to starter for production
+    privateServiceName: shipment-bot-api
     buildCommand: pip install -r requirements.txt && cd frontend && npm ci && npm run build
     preDeployCommand: python scripts/run_migrations.py
     startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
@@ -80,6 +81,7 @@ services:
     runtime: docker
     region: frankfurt
     plan: starter
+    privateServiceName: shipment-bot-wa-gateway
     rootDir: whatsapp_gateway
     healthCheckPath: /health
     disk:


### PR DESCRIPTION
## סיכום

**הבעיה:** ב-`render.yaml` השתמשנו ב-hostnames פנימיים (`http://shipment-bot-wa-gateway:10000`) אבל בלי להגדיר `privateServiceName` — מה ש-Render דורש כדי להפעיל DNS resolution פנימי בין שירותים.

**התיקון:** הוספתי `privateServiceName` לשני השירותים שמתקשרים פנימית:
- **`shipment-bot-api`** (שורה 13) — כדי שה-gateway יוכל לשלוח webhooks חזרה
- **`shipment-bot-wa-gateway`** (שורה 84) — כדי שה-API והעובד יוכלו לשלוח הודעות

אחרי שהשינוי יתפרס ב-Render (Blueprint Sync), השירותים יוכלו לתקשר פנימית, ובדיקת `/health/ready` אמורה לחזור ל-`healthy`.

---

ה-Private Service Discovery של Render דורש הגדרת privateServiceName מפורשת כדי שהשירותים יוכלו לתקשר פנימית דרך DNS.
בלי זה, ה-hostname shipment-bot-wa-gateway לא מתרזולב ומתקבלת שגיאת [Errno -2] Name or service not known.

נוסף privateServiceName ל:
- shipment-bot-api (כדי שה-gateway יוכל לשלוח webhooks חזרה)
- shipment-bot-wa-gateway (כדי שה-API והעובד יוכלו לשלוח הודעות)

https://claude.ai/code/session_01Dd6aVWYxrWr6WeQLoP8vRf

