### PR TITLE
Claude/review issue 101 1 go2m

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -42,6 +42,14 @@ class Settings(BaseSettings):
 
     # WhatsApp Gateway
     WHATSAPP_GATEWAY_URL: str = "http://localhost:3000"
+
+    @field_validator("WHATSAPP_GATEWAY_URL", mode="before")
+    @classmethod
+    def normalize_gateway_url(cls, v: str) -> str:
+        """Render fromService hostport מחזיר host:port בלבד — מוסיף http:// אם חסר"""
+        if v and not v.startswith("http"):
+            v = f"http://{v}"
+        return v.rstrip("/")
     WHATSAPP_ADMIN_GROUP_ID: Optional[str] = None  # קבוצת מנהלים - לסיכומי אישור/דחייה
 
     # מנהלים פרטיים - לשליחת כרטיסי נהג לאישור עם כפתורים

--- a/render.yaml
+++ b/render.yaml
@@ -10,7 +10,6 @@ services:
     runtime: python
     region: frankfurt
     plan: starter  # upgrade to starter for production
-    privateServiceName: shipment-bot-api
     buildCommand: pip install -r requirements.txt && cd frontend && npm ci && npm run build
     preDeployCommand: python scripts/run_migrations.py
     startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
@@ -35,7 +34,10 @@ services:
       - key: TELEGRAM_BOT_TOKEN
         sync: false  # Set manually in dashboard
       - key: WHATSAPP_GATEWAY_URL
-        value: "http://shipment-bot-wa-gateway:10000"
+        fromService:
+          type: web
+          name: shipment-bot-wa-gateway
+          property: hostport
       - key: JWT_SECRET_KEY
         sync: false  # Set manually in dashboard — openssl rand -hex 32
       - key: ADMIN_API_KEY
@@ -70,7 +72,10 @@ services:
       - key: TELEGRAM_BOT_TOKEN
         sync: false
       - key: WHATSAPP_GATEWAY_URL
-        value: "http://shipment-bot-wa-gateway:10000"
+        fromService:
+          type: web
+          name: shipment-bot-wa-gateway
+          property: hostport
     autoDeploy: true
 
   # =====================================================
@@ -81,7 +86,6 @@ services:
     runtime: docker
     region: frankfurt
     plan: starter
-    privateServiceName: shipment-bot-wa-gateway
     rootDir: whatsapp_gateway
     healthCheckPath: /health
     disk:
@@ -91,8 +95,11 @@ services:
     envVars:
       - key: NODE_ENV
         value: production
-      - key: API_WEBHOOK_URL
-        value: "http://shipment-bot-api:10000/api/whatsapp/webhook"
+      - key: API_HOSTPORT
+        fromService:
+          type: web
+          name: shipment-bot-api
+          property: hostport
     autoDeploy: true
 
   # =====================================================

--- a/whatsapp_gateway/index.js
+++ b/whatsapp_gateway/index.js
@@ -150,8 +150,10 @@ function truncateByCodepoints(text, maxLen, suffix = '…') {
     return chars.slice(0, maxLen - 1).join('') + suffix;
 }
 
-// Get API webhook URL from environment variable
-const API_WEBHOOK_URL = process.env.API_WEBHOOK_URL || 'http://localhost:8000/api/whatsapp/webhook';
+// בניית webhook URL — Render מספק API_HOSTPORT דרך fromService (host:port בלבד)
+const API_HOSTPORT = process.env.API_HOSTPORT;
+const API_WEBHOOK_URL = process.env.API_WEBHOOK_URL
+    || (API_HOSTPORT ? `http://${API_HOSTPORT}/api/whatsapp/webhook` : 'http://localhost:8000/api/whatsapp/webhook');
 
 // Session folder path - use absolute path for Render's disk mount
 const SESSION_FOLDER = '/app/sessions';


### PR DESCRIPTION
## סיכום מה שונה

| קובץ | שינוי |
|---|---|
| **render.yaml** | הוסר `privateServiceName` (שדה לא קיים). `WHATSAPP_GATEWAY_URL` ו-`API_HOSTPORT` עכשיו דרך `fromService` עם `property: hostport` — Render יספק את ה-hostname הפנימי האמיתי |
| **config.py** | validator חדש שמוסיף `http://` אם הערך הוא רק `host:port` |
| **index.js** | קורא `API_HOSTPORT` מ-env ובונה את ה-webhook URL. תומך ב-fallback ל-`API_WEBHOOK_URL` לתאימות אחורה |

אחרי המרג', Render יעשה Blueprint Sync ויזריק את ה-hostport הנכון דרך `fromService` — בלי לסמוך על DNS ידני.

Sources:
- [Blueprint YAML Reference – Render Docs](https://render.com/docs/blueprint-spec)
- [Private Network – Render Docs](https://render.com/docs/private-network)
- [fromService internal address - Render Community](https://community.render.com/t/render-yaml-blueprint-internal-address-environment-variable/4172)