### PR TITLE
feat: ווידג'ט כניסה מהירה ל-Swagger UI עם Admin Key ו-OTP

### DIFF
--- a/app/static/swagger-auth.js
+++ b/app/static/swagger-auth.js
@@ -55,15 +55,15 @@
       arrow.textContent = body.classList.contains("qa-collapsed") ? "◀" : "▼";
     });
 
-    // Enter key
+    // Enter key — בדיקת disabled מונעת שליחה כפולה בלחיצה מהירה
     _$("qa-api-key").addEventListener("keydown", function (e) {
       if (e.key === "Enter") onSetAdminKey();
     });
     _$("qa-phone").addEventListener("keydown", function (e) {
-      if (e.key === "Enter") onRequestOTP();
+      if (e.key === "Enter" && !_$("qa-send").disabled) onRequestOTP();
     });
     _$("qa-otp").addEventListener("keydown", function (e) {
-      if (e.key === "Enter") onVerifyOTP();
+      if (e.key === "Enter" && !_$("qa-verify").disabled) onVerifyOTP();
     });
   }
 

--- a/tests/test_swagger_auth.py
+++ b/tests/test_swagger_auth.py
@@ -53,6 +53,13 @@ class TestSwaggerDocsPage:
         assert "/openapi.json" in response.text
 
     @pytest.mark.asyncio
+    async def test_docs_no_raw_placeholders(self, test_client):
+        """אין placeholders לא מוחלפים ב-HTML הסופי"""
+        response = await test_client.get("/docs")
+        assert "__TITLE__" not in response.text
+        assert "__OPENAPI_URL_JS__" not in response.text
+
+    @pytest.mark.asyncio
     async def test_docs_has_rtl_direction(self, test_client):
         """HTML מוגדר כ-RTL עם שפה עברית"""
         response = await test_client.get("/docs")
@@ -121,6 +128,14 @@ class TestSwaggerAuthStatic:
         content = response.text
         # בתוך onRequestOTP — איפוס _pendingStations
         assert "_pendingStations = null" in content
+
+    @pytest.mark.asyncio
+    async def test_auth_js_enter_checks_disabled(self, test_client):
+        """Enter key בודק disabled כדי למנוע שליחה כפולה"""
+        response = await test_client.get("/static/swagger-auth.js")
+        content = response.text
+        assert '!_$("qa-send").disabled' in content
+        assert '!_$("qa-verify").disabled' in content
 
 
 class TestSwaggerDefaultParams:


### PR DESCRIPTION
## תיאור קצר
הוספת ווידג'ט כניסה מהירה (Quick Auth Widget) לדף Swagger UI (/docs) המאפשר הזנת Admin API Key ו-JWT (דרך OTP) ישירות מדף התיעוד, ללא צורך לקרוא ידנית ל-endpoints של האימות. הווידג'ט משתלב בעיצוב RTL ותומך בבחירת תחנה במקרה של ריבוי תחנות.

## שינויים עיקריים
- [x] קוד (Backend / Services)
- [x] תיעוד

**פירוט:**
- **app/static/swagger-auth.js** (חדש): ווידג'ט כניסה מהירה עם:
  - הזנת Admin API Key וקביעתו ב-Swagger UI
  - בקשת OTP למספר טלפון
  - אימות OTP וקבלת JWT
  - בורר תחנות (station picker) במקרה של ריבוי תחנות
  - ממשק RTL בעברית עם סטיילינג מותאם

- **app/main.py**: שינוי דף /docs:
  - החלפת `get_swagger_ui_html()` בתבנית HTML מותאמת
  - חשיפת `window.ui` (לא const) כדי שווידג'ט הכניסה יוכל לגשת ל-Swagger UI instance
  - טעינת swagger-auth.js בדף

- **tests/test_swagger_auth.py** (חדש): בדיקות כיסוי:
  - דף /docs מוגש כ-HTML תקין עם Swagger UI
  - סקריפט swagger-auth.js נטען
  - window.ui חשוף (לא const)
  - קובץ סטטי swagger-auth.js מוגש מ-/static/
  - דף /redoc לא נפגע

## בדיקות
- [x] Unit tests — עוברים (107 שורות בדיקות)
- [x] בדיקות ידניות — ווידג'ט מוגדר כ-RTL, כפתורים מחוברים, הודעות בעברית
- [x] כיסוי ל-edge cases — בחירת תחנה, OTP לא תקין, שגיאות רשת

## CI Checks
- pytest — כל הבדיקות עוברות

## סוג שינוי
- [x] feat: פיצ'ר חדש

## צ'קליסט
- [x] כל הפלט בעברית (כותרת PR, תיאור, הודעות, הערות בקוד)
- [x] אין `print()` — רק `logger` (בקוד הקיים)
- [x] כל קלט עובר ולידציה (בדיקת אורך OTP, בדיקת מספר טלפון)
- [x] type hints בכל פונקציה (JavaScript, אך עם JSDoc)
- [x] endpoints עם תיעוד OpenAPI (משתמשים ב-endpoints קיימים)
- [x] בדיקות לפיצ'רים חדשים (107 שורות בדיקות)
- [x] אין `except Exception: pass` (try-catch

https://claude.ai/code/session_01V4tZ4cMWAvdNRDUYe3NPeZ