### PR TITLE
תיקון: נעילת גרסת swagger-ui-dist ל-5.18.2 לפתרון שגיאת StandaloneLayout

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -230,8 +230,8 @@ _SWAGGER_HTML_TEMPLATE = """\
 </head>
 <body>
     <div id="swagger-ui"></div>
-    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
-    <script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-bundle.js"></script>
+    <script src="https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui-standalone-preset.js"></script>
     <script>
     window.ui = SwaggerUIBundle({
         url: __OPENAPI_URL_JS__,

--- a/app/static/swagger-rtl.css
+++ b/app/static/swagger-rtl.css
@@ -1,4 +1,4 @@
-@import url("https://unpkg.com/swagger-ui-dist@5/swagger-ui.css");
+@import url("https://unpkg.com/swagger-ui-dist@5.18.2/swagger-ui.css");
 
 /* RTL + Hebrew-friendly defaults for Swagger UI */
 html,


### PR DESCRIPTION
גרסאות חדשות של swagger-ui-dist@5 (ללא pinning) גורמות לשגיאה "No layout defined for StandaloneLayout" כי ה-standalone preset לא נרשם כראוי. נעילה לגרסה 5.18.2 פותרת את הבעיה.

https://claude.ai/code/session_01V4tZ4cMWAvdNRDUYe3NPeZ

תוקן! הבעיה הייתה ש-unpkg CDN עם `@5` (בלי pinning) החזיר גרסה חדשה של `swagger-ui-dist` שבה `SwaggerUIStandalonePreset` לא נרשם כראוי.

**מה שינתי:**
- `app/main.py` — נעילת שני ה-JS bundles לגרסה `5.18.2`
- `app/static/swagger-rtl.css` — נעילת ה-CSS import לאותה גרסה

אני רואה ש-`/static/swagger-rtl.css` מחזיר `304 Not Modified` — יתכן שהדפדפן עדיין מחזיק cache ישן עם ה-CSS import הלא-נעול. נסה **Ctrl+Shift+R** (hard refresh) בדפדפן כדי לאלץ טעינה מחדש של כל הקבצים.