### PR TITLE
הוספת בדיקות יחידה ו-ביצועים לעובדים ו-middleware

### DIFF
--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -459,5 +459,8 @@ class TestSetupMiddleware:
             "/api/telegram/webhook",
             json={"update_id": 1},
         )
-        # ייתכן 200 או שגיאה אחרת — העיקר שלא 429
-        assert response.status_code != 429
+        # הבקשה צריכה לעבור (200 — webhook מעובד בהצלחה)
+        assert response.status_code == 200
+        # headers מה-middleware stack חייבים להופיע
+        assert "x-correlation-id" in response.headers
+        assert response.headers.get("x-content-type-options") == "nosniff"


### PR DESCRIPTION
## תיאור קצר
הוספת סוויטת בדיקות ממוקדת לשתי מודולים קריטיים:
1. **Celery Workers** (`app/workers/tasks.py`) — עיבוד הודעות outbox, שידורים, ניקוי נתונים
2. **Middleware** (`app/core/middleware.py`) — correlation ID, logging, rate limiting, exception handling

הבדיקות מכסות happy path, edge cases, כשלונות, ביצועים (מניעת N+1 queries), ו-concurrency.

## שינויים עיקריים
- [ ] Celery / Workers
- [ ] תיעוד

### פירוט:
- **tests/test_celery_workers.py** (1224 שורות)
  - בדיקות שליחת WhatsApp ו-Telegram עם circuit breaker
  - שליפת נמענים (שליחים, סדרנים) עם סינון נכון
  - עיבוד הודעות בודדות וברודקאסט
  - ניקוי הודעות ישנות וחסימה אוטומטית
  - ניהול event loop ב-Celery

- **tests/test_middleware.py** (463 שורות)
  - מיסוך מספרי טלפון ב-URL (PII)
  - Correlation ID — יצירה ושימור
  - Request logging עם exception handling
  - WebhookRateLimitMiddleware — הגבלת קצב לפי IP
  - Exception handlers ל-AppException ו-generic exceptions

- **tests/test_performance.py** (344 שורות)
  - QueryCounter — כלי לספירת queries
  - מניעת N+1 queries בשליפות נפוצות
  - ביצועי batch operations
  - שימוש בזיכרון בשידורים גדולים

## בדיקות
- [x] Unit tests — 2031 שורות בדיקות
- [x] כיסוי edge cases: כשלונות, חסימות, סינון, concurrency
- [x] בדיקות ביצועים: N+1 prevention, batch operations, memory usage

## CI Checks
- pytest (כל הבדיקות עוברות)
- type hints בכל הבדיקות

## סוג שינוי
- [x] chore/ci: תשתית / בדיקות

## צ'קליסט
- [x] כל הפלט בעברית (כותרות, docstrings, הערות)
- [x] אין `print()` — רק assertions
- [x] type hints בכל פונקציה
- [x] בדיקות לכל הפיצ'רים הקיימים
- [x] בדיקת authorization (כשרלוונטי)
- [x] בדיקת N+1 queries עם QueryCounter
- [x] בדיקת concurrency — asyncio.gather, parallel sends
- [x] הודעות שגיאה ברורות בעברית
- [x] עובד זהה בטלגרם ובוואטסאפ

## השפעות / סיכונים
- **אין השפעה על קוד פרודקשן** — בדיקות בלבד
- **מניעת רגרסיות** — כיסוי מלא של workers ו-middleware
- **ביצועים** —

https://claude.ai/code/session_01HxovVLcu7XR4pu8tN9Bv5j