### PR TITLE
feat: אימות webhook של טלגרם עם X-Telegram-Bot-Api-Secret-Token

### DIFF
--- a/app/api/dependencies/webhook_auth.py
+++ b/app/api/dependencies/webhook_auth.py
@@ -1,0 +1,53 @@
+"""
+אימות חתימת webhook נכנס מטלגרם.
+
+טלגרם שולח את הכותרת ``X-Telegram-Bot-Api-Secret-Token``
+עם כל בקשת webhook אם הוגדר ``secret_token`` בקריאת ``setWebhook``.
+ה-dependency הזה מוודא שהכותרת תואמת לטוקן שמוגדר בסביבה.
+
+שימוש:
+    @router.post("/webhook")
+    async def telegram_webhook(
+        ...,
+        _: None = Depends(verify_telegram_webhook_token),
+    ):
+        ...
+"""
+import hmac
+
+from fastapi import Depends, Header, HTTPException, status
+
+from app.core.config import settings
+from app.core.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+async def verify_telegram_webhook_token(
+    x_telegram_bot_api_secret_token: str | None = Header(None),
+) -> None:
+    """
+    אימות ``X-Telegram-Bot-Api-Secret-Token`` בבקשות webhook מטלגרם.
+
+    - אם ``TELEGRAM_WEBHOOK_SECRET_TOKEN`` לא מוגדר — מדלג (אזהרה בלוג).
+    - אם הכותרת חסרה או לא תואמת — 403 Forbidden.
+    """
+    expected = settings.TELEGRAM_WEBHOOK_SECRET_TOKEN
+    if not expected:
+        # טוקן לא מוגדר — אין אימות (אזהרה כבר נרשמת ב-startup)
+        return
+
+    if not x_telegram_bot_api_secret_token:
+        logger.warning("בקשת webhook ללא כותרת X-Telegram-Bot-Api-Secret-Token")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="חסר טוקן אימות webhook",
+        )
+
+    # השוואה בטוחה מפני timing attacks
+    if not hmac.compare_digest(x_telegram_bot_api_secret_token, expected):
+        logger.warning("בקשת webhook עם טוקן שגוי")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="טוקן אימות webhook לא תקין",
+        )

--- a/app/api/webhooks/telegram.py
+++ b/app/api/webhooks/telegram.py
@@ -25,6 +25,7 @@ from app.core.logging import get_logger
 from app.core.circuit_breaker import get_telegram_circuit_breaker
 from app.core.config import settings
 from app.core.exceptions import TelegramError
+from app.api.dependencies.webhook_auth import verify_telegram_webhook_token
 
 logger = get_logger(__name__)
 
@@ -706,13 +707,16 @@ async def _route_to_role_menu(
     summary="Webhook - Telegram (קבלת עדכונים נכנסים)",
     description=(
         "נקודת כניסה לקבלת עדכונים מ-Telegram Bot API. "
-        "תומכת גם בהודעות טקסט/תמונות וגם ב-callback queries (כפתורים)."
+        "תומכת גם בהודעות טקסט/תמונות וגם ב-callback queries (כפתורים). "
+        "מאומת באמצעות X-Telegram-Bot-Api-Secret-Token."
     ),
+    responses={403: {"description": "טוקן אימות webhook חסר או שגוי"}},
 )
 async def telegram_webhook(
     update: TelegramUpdate,
     background_tasks: BackgroundTasks,
-    db: AsyncSession = Depends(get_db)
+    db: AsyncSession = Depends(get_db),
+    _: None = Depends(verify_telegram_webhook_token),
 ):
     """
     Handle incoming Telegram messages.

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -63,6 +63,7 @@ class Settings(BaseSettings):
     # Telegram
     TELEGRAM_BOT_TOKEN: Optional[str] = None
     TELEGRAM_ADMIN_CHAT_ID: Optional[str] = None  # קבוצת מנהלים בטלגרם - לסיכומי אישור/דחייה
+    TELEGRAM_WEBHOOK_SECRET_TOKEN: str = ""  # אימות webhook — openssl rand -hex 32
 
     # Credit settings
     DEFAULT_CREDIT_LIMIT: float = -500.0  # Minimum balance allowed (500₪ credit)
@@ -114,7 +115,8 @@ class Settings(BaseSettings):
         """ולידציות חוצות-שדות לסביבת פרודקשן.
 
         1. JWT_SECRET_KEY ריק בפרודקשן — זורק ValueError שעוצר את ההפעלה.
-        2. DEBUG=True עם DB חיצוני — אזהרה שייתכן ששכחו לכבות DEBUG.
+        2. TELEGRAM_WEBHOOK_SECRET_TOKEN ריק — אזהרה (webhook לא מאומת).
+        3. DEBUG=True עם DB חיצוני — אזהרה שייתכן ששכחו לכבות DEBUG.
         """
         import warnings
 
@@ -128,6 +130,15 @@ class Settings(BaseSettings):
                 )
             warnings.warn(
                 "JWT_SECRET_KEY ריק — הפאנל לא יעבוד. הגדר בסביבת הייצור: openssl rand -hex 32",
+                stacklevel=2,
+            )
+
+        # --- TELEGRAM_WEBHOOK_SECRET_TOKEN ---
+        if not self.TELEGRAM_WEBHOOK_SECRET_TOKEN and self.TELEGRAM_BOT_TOKEN:
+            warnings.warn(
+                "TELEGRAM_WEBHOOK_SECRET_TOKEN ריק — webhook של טלגרם לא מאומת. "
+                "הגדר: export TELEGRAM_WEBHOOK_SECRET_TOKEN=$(openssl rand -hex 32) "
+                "ועדכן את ה-secret_token בקריאת setWebhook.",
                 stacklevel=2,
             )
 

--- a/tests/test_telegram_webhook_auth.py
+++ b/tests/test_telegram_webhook_auth.py
@@ -1,0 +1,107 @@
+"""
+בדיקות לאימות חתימת webhook מטלגרם (X-Telegram-Bot-Api-Secret-Token).
+"""
+import pytest
+from unittest.mock import patch
+
+from app.core.config import settings
+from app.api.dependencies.webhook_auth import verify_telegram_webhook_token
+
+
+# ──────────────────────────────────────────────
+#  בדיקות יחידה ל-dependency
+# ──────────────────────────────────────────────
+
+class TestVerifyTelegramWebhookToken:
+    """בדיקות ישירות ל-dependency — ללא HTTP."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_skips_when_secret_not_configured(self) -> None:
+        """אם TELEGRAM_WEBHOOK_SECRET_TOKEN ריק — מדלג ללא שגיאה."""
+        with patch.object(settings, "TELEGRAM_WEBHOOK_SECRET_TOKEN", ""):
+            # לא צריך לזרוק exception
+            await verify_telegram_webhook_token(None)
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_rejects_missing_header(self) -> None:
+        """אם הטוקן מוגדר אבל הכותרת חסרה — 403."""
+        from fastapi import HTTPException
+        with patch.object(settings, "TELEGRAM_WEBHOOK_SECRET_TOKEN", "my-secret"):
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_telegram_webhook_token(None)
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_rejects_wrong_token(self) -> None:
+        """אם הטוקן לא תואם — 403."""
+        from fastapi import HTTPException
+        with patch.object(settings, "TELEGRAM_WEBHOOK_SECRET_TOKEN", "my-secret"):
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_telegram_webhook_token("wrong-token")
+            assert exc_info.value.status_code == 403
+
+    @pytest.mark.asyncio
+    @pytest.mark.unit
+    async def test_accepts_valid_token(self) -> None:
+        """אם הטוקן תואם — עובר ללא שגיאה."""
+        with patch.object(settings, "TELEGRAM_WEBHOOK_SECRET_TOKEN", "my-secret"):
+            await verify_telegram_webhook_token("my-secret")
+
+
+# ──────────────────────────────────────────────
+#  בדיקות אינטגרציה — HTTP מלא
+# ──────────────────────────────────────────────
+
+_VALID_UPDATE = {
+    "update_id": 100,
+    "message": {
+        "message_id": 1,
+        "chat": {"id": 12345, "type": "private"},
+        "text": "שלום",
+        "date": 1700000000,
+        "from": {"id": 12345, "first_name": "Test"},
+    },
+}
+
+
+class TestWebhookAuthIntegration:
+    """בדיקות HTTP דרך test_client — ולידציה שה-dependency מחובר ל-endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_webhook_rejects_missing_token_when_configured(self, test_client) -> None:
+        """כותרת חסרה + טוקן מוגדר → 403."""
+        with patch.object(settings, "TELEGRAM_WEBHOOK_SECRET_TOKEN", "test-secret-abc"):
+            resp = await test_client.post("/api/telegram/webhook", json=_VALID_UPDATE)
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_webhook_rejects_wrong_token(self, test_client) -> None:
+        """כותרת שגויה + טוקן מוגדר → 403."""
+        with patch.object(settings, "TELEGRAM_WEBHOOK_SECRET_TOKEN", "test-secret-abc"):
+            resp = await test_client.post(
+                "/api/telegram/webhook",
+                json=_VALID_UPDATE,
+                headers={"X-Telegram-Bot-Api-Secret-Token": "wrong-value"},
+            )
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_webhook_accepts_valid_token(self, test_client) -> None:
+        """כותרת תואמת → 200."""
+        with patch.object(settings, "TELEGRAM_WEBHOOK_SECRET_TOKEN", "test-secret-abc"):
+            resp = await test_client.post(
+                "/api/telegram/webhook",
+                json=_VALID_UPDATE,
+                headers={"X-Telegram-Bot-Api-Secret-Token": "test-secret-abc"},
+            )
+            assert resp.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_webhook_passes_when_secret_not_configured(self, test_client) -> None:
+        """טוקן לא מוגדר → webhook עובר ללא אימות (תאימות לאחור)."""
+        with patch.object(settings, "TELEGRAM_WEBHOOK_SECRET_TOKEN", ""):
+            resp = await test_client.post("/api/telegram/webhook", json=_VALID_UPDATE)
+            assert resp.status_code == 200


### PR DESCRIPTION
## תיאור קצר
הוספת מנגנון אימות לבקשות webhook נכנסות מטלגרם באמצעות כותרת `X-Telegram-Bot-Api-Secret-Token`. זה מגביר את האבטחה של ה-webhook ומונע בקשות זדוניות מחוץ לטלגרם.

## שינויים עיקריים
- [x] קוד (Backend / Services)
- [x] בוט טלגרם
- [x] תיעוד

**פירוט:**
- יצירת `app/api/dependencies/webhook_auth.py` — dependency חדש המאמת את הטוקן באמצעות `hmac.compare_digest()` (הגנה מפני timing attacks)
- עדכון `app/api/webhooks/telegram.py` — חיבור ה-dependency ל-endpoint `/api/telegram/webhook`
- הוספת `TELEGRAM_WEBHOOK_SECRET_TOKEN` ל-`app/core/config.py` עם ולידציה בפרודקשן (אזהרה אם לא מוגדר)
- תיעוד OpenAPI עם תגובת 403 בעת כשל אימות

## בדיקות
- [x] Unit tests — עוברים (4 בדיקות יחידה ל-dependency)
- [x] בדיקות אינטגרציה — עוברים (4 בדיקות HTTP דרך test_client)
- [x] כיסוי ל-edge cases:
  - טוקן לא מוגדר (דילוג על אימות)
  - כותרת חסרה (403)
  - טוקן שגוי (403)
  - טוקן תקין (200)

## CI Checks
- pytest — כל הבדיקות עוברות
- ולידציית דיאגרמות — לא רלוונטי לשינוי זה

## סוג שינוי
- [x] feat: פיצ'ר חדש

## צ'קליסט
- [x] כל הפלט בעברית (כותרת PR, תיאור, הודעות, הערות בקוד)
- [x] אין `print()` — רק `logger`
- [x] כל קלט עובר ולידציה (כותרת HTTP מטלגרם)
- [x] type hints בכל פונקציה
- [x] endpoints עם תיעוד OpenAPI (תגובת 403 מתועדת)
- [x] בדיקות לפיצ'ר חדש (7 בדיקות)
- [x] אין `except Exception: pass`
- [x] בדיקת authorization לפני כל פעולה (אימות webhook)
- [x] הודעות שגיאה ברורות בעברית
- [x] מספיק לוגים לדיבאג בפרודקשן (warning בעת כשל)

## השפעות / סיכונים
**אבטחה:** שיפור משמעותי — webhook מאומת כעת מפני בקשות זדוניות.

**תאימות לאחור:** אם `TELEGRAM_WEBHOOK_SECRET_TOKEN` לא מוגדר, ה-webhook עובר ללא אימות (דיפולט בטוח).

**פרודקשן:** יש להגדיר `TELEGRAM_

https://claude.ai/code/session_01Tg5jKHY3Y8rjSzHRhStm6X