### PR TITLE
תיקון: קריסת escape(None) בניהול סדרנים ורשימה שחורה + שיפור לוגים 403

### DIFF
--- a/app/state_machine/station_owner_handler.py
+++ b/app/state_machine/station_owner_handler.py
@@ -385,7 +385,9 @@ class StationOwnerStateHandler:
                     select(User).where(User.id == d.user_id)
                 )
                 dispatcher_user = result.scalar_one_or_none()
-                name = dispatcher_user.name if dispatcher_user else "לא ידוע"
+                name = (
+                    dispatcher_user.full_name or dispatcher_user.name or "לא ידוע"
+                ) if dispatcher_user else "לא ידוע"
                 text += f"{i}. {escape(name)}\n"
         else:
             text += "אין סדרנים רשומים עדיין.\n"
@@ -463,7 +465,9 @@ class StationOwnerStateHandler:
                 select(User).where(User.id == d.user_id)
             )
             dispatcher_user = result.scalar_one_or_none()
-            name = dispatcher_user.name if dispatcher_user else "לא ידוע"
+            name = (
+                dispatcher_user.full_name or dispatcher_user.name or "לא ידוע"
+            ) if dispatcher_user else "לא ידוע"
             text += f"{i}. {escape(name)}\n"
             keyboard_items.append([f"הסר {i}"])
             dispatcher_map[str(i)] = d.user_id
@@ -493,7 +497,9 @@ class StationOwnerStateHandler:
                 select(User).where(User.id == dispatcher_user_id)
             )
             dispatcher_user = result.scalar_one_or_none()
-            name = dispatcher_user.name if dispatcher_user else "לא ידוע"
+            name = (
+                dispatcher_user.full_name or dispatcher_user.name or "לא ידוע"
+            ) if dispatcher_user else "לא ידוע"
 
             response = MessageResponse(
                 f"⚠️ <b>אישור הסרת סדרן</b>\n\n"
@@ -628,7 +634,9 @@ class StationOwnerStateHandler:
                     select(User).where(User.id == entry.courier_id)
                 )
                 blocked_user = result.scalar_one_or_none()
-                name = blocked_user.name if blocked_user else "לא ידוע"
+                name = (
+                    blocked_user.full_name or blocked_user.name or "לא ידוע"
+                ) if blocked_user else "לא ידוע"
                 reason = entry.reason or "אי תשלום"
                 text += f"{i}. {escape(name)} - {escape(reason)}\n"
         else:
@@ -729,7 +737,9 @@ class StationOwnerStateHandler:
                 select(User).where(User.id == entry.courier_id)
             )
             blocked_user = result.scalar_one_or_none()
-            name = blocked_user.name if blocked_user else "לא ידוע"
+            name = (
+                blocked_user.full_name or blocked_user.name or "לא ידוע"
+            ) if blocked_user else "לא ידוע"
             text += f"{i}. {escape(name)}\n"
             keyboard_items.append([f"הסר {i}"])
             blacklist_map[str(i)] = entry.courier_id
@@ -759,7 +769,9 @@ class StationOwnerStateHandler:
                 select(User).where(User.id == courier_id)
             )
             blocked_user = result.scalar_one_or_none()
-            name = blocked_user.name if blocked_user else "לא ידוע"
+            name = (
+                blocked_user.full_name or blocked_user.name or "לא ידוע"
+            ) if blocked_user else "לא ידוע"
 
             response = MessageResponse(
                 f"⚠️ <b>אישור הסרה מרשימה שחורה</b>\n\n"

--- a/tests/test_station_owner_none_name.py
+++ b/tests/test_station_owner_none_name.py
@@ -1,0 +1,272 @@
+"""
+בדיקות: תצוגת שמות None בניהול סדרנים ורשימה שחורה
+
+מוודא שכאשר dispatcher/courier נוצרים דרך get_or_create_user_by_phone
+(בלי שם), ה-handler לא קורס ומציג "לא ידוע" במקום.
+"""
+import pytest
+from sqlalchemy import select
+
+from app.db.models.user import User, UserRole
+from app.db.models.station import Station
+from app.db.models.station_owner import StationOwner
+from app.db.models.station_dispatcher import StationDispatcher
+from app.db.models.station_blacklist import StationBlacklist
+from app.db.models.station_wallet import StationWallet
+from app.state_machine.states import StationOwnerState
+from app.state_machine.station_owner_handler import StationOwnerStateHandler
+from app.state_machine.manager import StateManager
+
+
+class TestDispatcherNoneName:
+    """בדיקות: סדרנים עם name=None לא גורמים לקריסה"""
+
+    async def _setup_station_with_nameless_dispatcher(
+        self, user_factory, db_session
+    ):
+        """הקמת תחנה עם סדרן ללא שם (סימולציה של get_or_create_user_by_phone)"""
+        owner = await user_factory(
+            phone_number="+972501234567",
+            name="בעלים",
+            role=UserRole.STATION_OWNER,
+        )
+        # סדרן שנוצר דרך get_or_create_user_by_phone — בלי שם
+        dispatcher = await user_factory(
+            phone_number="+972509999999",
+            name=None,
+            full_name=None,
+            role=UserRole.SENDER,
+        )
+        station = Station(name="תחנת בדיקה", owner_id=owner.id)
+        db_session.add(station)
+        await db_session.flush()
+        db_session.add(StationWallet(station_id=station.id))
+        db_session.add(StationOwner(station_id=station.id, user_id=owner.id))
+        db_session.add(
+            StationDispatcher(station_id=station.id, user_id=dispatcher.id)
+        )
+        await db_session.commit()
+        return owner, dispatcher, station
+
+    @pytest.mark.asyncio
+    async def test_manage_dispatchers_with_none_name(
+        self, user_factory, db_session
+    ):
+        """תצוגת סדרנים לא קורסת כשלסדרן אין שם"""
+        owner, dispatcher, station = (
+            await self._setup_station_with_nameless_dispatcher(
+                user_factory, db_session
+            )
+        )
+        state_mgr = StateManager(db_session)
+        await state_mgr.force_state(
+            owner.id, "telegram", StationOwnerState.MENU.value, {}
+        )
+
+        handler = StationOwnerStateHandler(db_session, station.id)
+        response, new_state = await handler.handle_message(
+            owner, "👥 ניהול סדרנים", None
+        )
+
+        assert new_state == StationOwnerState.MANAGE_DISPATCHERS.value
+        # "לא ידוע" במקום קריסה על escape(None)
+        assert "לא ידוע" in response.text
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_removal_list_with_none_name(
+        self, user_factory, db_session
+    ):
+        """רשימת סדרנים להסרה לא קורסת כשלסדרן אין שם"""
+        owner, dispatcher, station = (
+            await self._setup_station_with_nameless_dispatcher(
+                user_factory, db_session
+            )
+        )
+        state_mgr = StateManager(db_session)
+        await state_mgr.force_state(
+            owner.id,
+            "telegram",
+            StationOwnerState.MANAGE_DISPATCHERS.value,
+            {},
+        )
+
+        handler = StationOwnerStateHandler(db_session, station.id)
+        response, new_state = await handler.handle_message(
+            owner, "➖ הסרת סדרן", None
+        )
+
+        assert new_state == StationOwnerState.REMOVE_DISPATCHER_SELECT.value
+        assert "לא ידוע" in response.text
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_confirm_remove_with_none_name(
+        self, user_factory, db_session
+    ):
+        """אישור הסרת סדרן ללא שם לא קורס"""
+        owner, dispatcher, station = (
+            await self._setup_station_with_nameless_dispatcher(
+                user_factory, db_session
+            )
+        )
+        state_mgr = StateManager(db_session)
+        await state_mgr.force_state(
+            owner.id,
+            "telegram",
+            StationOwnerState.REMOVE_DISPATCHER_SELECT.value,
+            {"dispatcher_map": {"1": dispatcher.id}},
+        )
+
+        handler = StationOwnerStateHandler(db_session, station.id)
+        response, new_state = await handler.handle_message(
+            owner, "הסר 1", None
+        )
+
+        assert new_state == StationOwnerState.CONFIRM_REMOVE_DISPATCHER.value
+        assert "לא ידוע" in response.text
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_with_full_name_only(
+        self, user_factory, db_session
+    ):
+        """סדרן עם full_name בלבד (בלי name) מציג full_name"""
+        owner = await user_factory(
+            phone_number="+972501234567",
+            name="בעלים",
+            role=UserRole.STATION_OWNER,
+        )
+        dispatcher = await user_factory(
+            phone_number="+972509999999",
+            name=None,
+            full_name="יוסי כהן",
+            role=UserRole.SENDER,
+        )
+        station = Station(name="תחנת בדיקה", owner_id=owner.id)
+        db_session.add(station)
+        await db_session.flush()
+        db_session.add(StationWallet(station_id=station.id))
+        db_session.add(StationOwner(station_id=station.id, user_id=owner.id))
+        db_session.add(
+            StationDispatcher(station_id=station.id, user_id=dispatcher.id)
+        )
+        await db_session.commit()
+
+        state_mgr = StateManager(db_session)
+        await state_mgr.force_state(
+            owner.id, "telegram", StationOwnerState.MENU.value, {}
+        )
+
+        handler = StationOwnerStateHandler(db_session, station.id)
+        response, new_state = await handler.handle_message(
+            owner, "👥 ניהול סדרנים", None
+        )
+
+        assert "יוסי כהן" in response.text
+
+
+class TestBlacklistNoneName:
+    """בדיקות: נהגים ברשימה שחורה עם name=None לא גורמים לקריסה"""
+
+    async def _setup_station_with_nameless_blacklisted(
+        self, user_factory, db_session
+    ):
+        """הקמת תחנה עם נהג חסום ללא שם"""
+        owner = await user_factory(
+            phone_number="+972501234567",
+            name="בעלים",
+            role=UserRole.STATION_OWNER,
+        )
+        courier = await user_factory(
+            phone_number="+972508888888",
+            name=None,
+            full_name=None,
+            role=UserRole.COURIER,
+        )
+        station = Station(name="תחנת בדיקה", owner_id=owner.id)
+        db_session.add(station)
+        await db_session.flush()
+        db_session.add(StationWallet(station_id=station.id))
+        db_session.add(StationOwner(station_id=station.id, user_id=owner.id))
+        db_session.add(
+            StationBlacklist(
+                station_id=station.id,
+                courier_id=courier.id,
+                reason="אי תשלום",
+            )
+        )
+        await db_session.commit()
+        return owner, courier, station
+
+    @pytest.mark.asyncio
+    async def test_blacklist_view_with_none_name(
+        self, user_factory, db_session
+    ):
+        """תצוגת רשימה שחורה לא קורסת כשלנהג אין שם"""
+        owner, courier, station = (
+            await self._setup_station_with_nameless_blacklisted(
+                user_factory, db_session
+            )
+        )
+        state_mgr = StateManager(db_session)
+        await state_mgr.force_state(
+            owner.id, "telegram", StationOwnerState.MENU.value, {}
+        )
+
+        handler = StationOwnerStateHandler(db_session, station.id)
+        response, new_state = await handler.handle_message(
+            owner, "🚫 רשימה שחורה", None
+        )
+
+        assert new_state == StationOwnerState.VIEW_BLACKLIST.value
+        assert "לא ידוע" in response.text
+
+    @pytest.mark.asyncio
+    async def test_blacklist_removal_list_with_none_name(
+        self, user_factory, db_session
+    ):
+        """רשימת נהגים חסומים להסרה לא קורסת כשלנהג אין שם"""
+        owner, courier, station = (
+            await self._setup_station_with_nameless_blacklisted(
+                user_factory, db_session
+            )
+        )
+        state_mgr = StateManager(db_session)
+        await state_mgr.force_state(
+            owner.id,
+            "telegram",
+            StationOwnerState.VIEW_BLACKLIST.value,
+            {},
+        )
+
+        handler = StationOwnerStateHandler(db_session, station.id)
+        response, new_state = await handler.handle_message(
+            owner, "➖ הסרת נהג מהרשימה", None
+        )
+
+        assert new_state == StationOwnerState.REMOVE_BLACKLIST_SELECT.value
+        assert "לא ידוע" in response.text
+
+    @pytest.mark.asyncio
+    async def test_blacklist_confirm_remove_with_none_name(
+        self, user_factory, db_session
+    ):
+        """אישור הסרה מרשימה שחורה ללא שם לא קורס"""
+        owner, courier, station = (
+            await self._setup_station_with_nameless_blacklisted(
+                user_factory, db_session
+            )
+        )
+        state_mgr = StateManager(db_session)
+        await state_mgr.force_state(
+            owner.id,
+            "telegram",
+            StationOwnerState.REMOVE_BLACKLIST_SELECT.value,
+            {"blacklist_map": {"1": courier.id}},
+        )
+
+        handler = StationOwnerStateHandler(db_session, station.id)
+        response, new_state = await handler.handle_message(
+            owner, "הסר 1", None
+        )
+
+        assert new_state == StationOwnerState.CONFIRM_REMOVE_BLACKLIST.value
+        assert "לא ידוע" in response.text


### PR DESCRIPTION
באג: כשנוסף סדרן/נהג דרך get_or_create_user_by_phone בלי שם, escape(None) זורק AttributeError וגורם לקריסת הבוט.

תיקון: החלפת `user.name if user else "לא ידוע"` בפתרון העקבי `(user.full_name or user.name or "לא ידוע") if user else "לא ידוע"` ב-6 מקומות (3 סדרנים + 3 רשימה שחורה).

שיפור: שדרוג לוגים ב-auth dependency מ-WARNING ל-ERROR עם פרטים נוספים (user_found, is_active, station_name) — מקל על דיבוג 403.

https://claude.ai/code/session_013pAnsDFCJgrPXPp9AGPmqm



הכל נעשה. הנה סיכום:

## מה תוקן

### באג 1: קריסת `escape(None)` ב-WhatsApp handler
כשסדרן או נהג ברשימה שחורה נוצרים דרך `get_or_create_user_by_phone` (למשל, מהפאנל), הם נוצרים **בלי שם** (`name=None`, `full_name=None`). הקוד ב-`station_owner_handler.py` עשה `escape(name)` על `None` ← **AttributeError**.

**תיקון**: 6 מקומות הוחלפו מ:
```python
name = dispatcher_user.name if dispatcher_user else "לא ידוע"
```
ל:
```python
name = (
    dispatcher_user.full_name or dispatcher_user.name or "לא ידוע"
) if dispatcher_user else "לא ידוע"
```

### באג 2: 403 Forbidden בפאנל — שיפור דיבוג
הלוגים ב-auth dependency היו ברמת `WARNING` — לכן לא מצאת אותם כשחיפשת. שודרגו ל-`ERROR` עם פרטים נוספים (`user_found`, `is_active`, `station_name`). **בפעם הבאה שה-403 יקרה, תוכל לראות מיד בדיוק מה נכשל**.

לגבי ה-403 עצמו — הקוד נראה תקין. הסיבות האפשריות:
- **טוקן פג תוקף** — האדמין השני צריך להתחבר מחדש
- **ownership mismatch** — האדמין לא מקושר נכון בטבלת `station_owners`
- **תחנה לא פעילה** — `station.is_active = False`

עכשיו, אחרי השדרוג, הלוגים ברמת ERROR יגידו לך בדיוק מה הבעיה.