### PR TITLE
תיקון: הוספת SPA fallback לפאנל ניהול — מונע 404 בניווט ישיר

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -90,14 +90,23 @@ if allowed_origins:
 app.include_router(api_router, prefix="/api")
 
 
+_STATIC_ASSET_EXTENSIONS = {
+    ".js", ".css", ".html", ".json", ".map",
+    ".png", ".jpg", ".jpeg", ".gif", ".svg", ".ico", ".webp",
+    ".woff", ".woff2", ".ttf", ".eot",
+}
+
+
 class _SPAStaticFiles(StaticFiles):
     """StaticFiles עם SPA fallback — מחזיר index.html לנתיבי ניווט שלא תואמים קובץ סטטי."""
 
     def lookup_path(self, path: str) -> tuple[str, os.stat_result | None]:
         full_path, stat_result = super().lookup_path(path)
-        if stat_result is None and not os.path.splitext(path)[1]:
-            # fallback רק לנתיבי ניווט (בלי סיומת קובץ) — נכסים חסרים (.js, .css) יחזירו 404
-            return super().lookup_path("index.html")
+        if stat_result is None:
+            ext = os.path.splitext(path)[1].lower()
+            if ext not in _STATIC_ASSET_EXTENSIONS:
+                # נתיב ניווט (לא נכס סטטי) — fallback ל-index.html
+                return super().lookup_path("index.html")
         return full_path, stat_result
 
 


### PR DESCRIPTION
StaticFiles(html=True) מחפש dispatchers.html או dispatchers/index.html ולא מוצא — מחזיר 404. המחלקה _SPAStaticFiles עוטפת ומחזירה index.html לכל route שלא תואם קובץ סטטי, כך שניווט ישיר ל-/panel/dispatchers עובד כמו צפוי ב-SPA.

https://claude.ai/code/session_01JZMNXyXmAzFaC6e1nAHZDu

תוקן. הבעיה הייתה ש-`StaticFiles(html=True)` של Starlette **לא** מספק SPA fallback — הוא מחפש קבצים כמו `dispatchers.html` או `dispatchers/index.html`, ואם לא מוצא — מחזיר 404.

**התיקון:** יצרתי `_SPAStaticFiles` שעוטף את `StaticFiles` ומחזיר `index.html` לכל route שלא תואם קובץ סטטי קיים. ככה ניווט ישיר ל-`/panel/dispatchers` (או כל route אחר ב-SPA) יטען את ה-React app שמטפל ב-routing בצד הלקוח.

