### PR TITLE
תמיכה ברשימת בחירה אינטראקטיבית (4-10 כפתורים) בוואטסאפ

### DIFF
--- a/app/domain/services/whatsapp/pywa_provider.py
+++ b/app/domain/services/whatsapp/pywa_provider.py
@@ -239,7 +239,12 @@ class PyWaProvider(BaseWhatsAppProvider):
 
     @staticmethod
     def _keyboard_to_text_instructions(keyboard: list[list[str]] | None) -> str:
-        """המרת כפתורים להנחיות טקסטואליות (fallback כשיש יותר מ-3 כפתורים)."""
+        """המרת כפתורים להנחיות טקסטואליות.
+
+        נקרא רק כש-buttons ו-list שניהם נכשלו (guard על אורך,
+        כפילויות, או חריגה מכמות מקסימלית). לכן — תמיד מספק
+        הנחיות בלי קשר לכמות הפריטים.
+        """
         if not keyboard:
             return ""
 
@@ -250,7 +255,7 @@ class PyWaProvider(BaseWhatsAppProvider):
             else:
                 all_labels.append(str(row))
 
-        if not all_labels or len(all_labels) <= _MAX_REPLY_BUTTONS:
+        if not all_labels:
             return ""
 
         lines = ["\n\nהקלד בדיוק את טקסט האפשרות הרצויה:"]

--- a/tests/test_pywa_provider.py
+++ b/tests/test_pywa_provider.py
@@ -203,7 +203,7 @@ class TestPyWaSendText:
     @pytest.mark.unit
     @pytest.mark.asyncio
     async def test_send_text_button_callback_too_long_fallback(self) -> None:
-        """כפתור עם callback_data שחורג מ-256 — כפתורים לא נוצרים, נופל לרשימה/טקסט."""
+        """כפתור עם callback_data שחורג מ-256 — fallback טקסטואלי גם ב-≤3 אפשרויות."""
         provider, _ = self._make_provider()
 
         mock_client = AsyncMock()
@@ -211,8 +211,6 @@ class TestPyWaSendText:
         provider._client = mock_client
 
         mock_pywa_types = MagicMock()
-        # label אחד שחורג מ-256 תווים — עם כפתור אחד אין fallback טקסטואלי
-        # (≤3 אפשרויות), אבל הכפתור לא ייווצר
         long_label = "א" * 300
 
         with patch.dict("sys.modules", {"pywa": MagicMock(types=mock_pywa_types), "pywa.types": mock_pywa_types}):
@@ -224,6 +222,8 @@ class TestPyWaSendText:
         call_kwargs = mock_client.send_message.call_args[1]
         # כפתור לא נוצר בגלל guard — buttons=None
         assert call_kwargs["buttons"] is None
+        # fallback טקסטואלי נכנס גם ב-≤3 אפשרויות
+        assert "הקלד בדיוק את טקסט האפשרות הרצויה:" in call_kwargs["text"]
 
     @pytest.mark.unit
     @pytest.mark.asyncio


### PR DESCRIPTION
## תיאור קצר
הוספת תמיכה ברשימת בחירה אינטראקטיבית (Interactive List Message) בספק וואטסאפ PyWa. כאשר יש 4-10 אפשרויות, המערכת תשלח רשימה אינטראקטיבית במקום להיזום להנחיות טקסטואליות. זה משפר את חוויית המשתמש על ידי שמירה על ממשק אינטראקטיבי גם כשמספר הכפתורים עולה על 3.

## שינויים עיקריים
- [x] קוד (Backend / Services)
- [x] בוט וואטסאפ

פירוט:
- הוספת קבוע `_MAX_LIST_ROWS = 10` להגדרת המגבלה העליונה של פריטים ברשימה
- יצירת מתודה חדשה `_build_list_message()` שממירה keyboard לרשימת בחירה אינטראקטיבית (SectionList)
  - תומכת ב-4-10 אפשרויות
  - חותכת את title של כל שורה ל-24 תווים (מגבלת Cloud API)
  - שומרת את callback_data המלא (עד 200 תווים)
- עדכון לוגיקת `send_text()` לסדר עדיפויות:
  1. כפתורי reply (≤3 אפשרויות)
  2. רשימת בחירה (4-10 אפשרויות)
  3. fallback טקסטואלי (>10 אפשרויות)

## בדיקות
- [x] Unit tests — עוברים
- [x] כיסוי ל-edge cases

פירוט:
- `test_send_text_keyboard_list_message`: בדיקת שליחת רשימה עם 4 אפשרויות
- `test_send_text_keyboard_text_fallback_over_10`: בדיקת fallback טקסטואלי עם 11 אפשרויות
- `test_send_text_list_message_row_title_truncated`: בדיקת חיתוך title ל-24 תווים תוך שמירה על callback_data המלא

## CI Checks
- ✅ pytest — כל הבדיקות עוברות
- ✅ ולידציית דיאגרמות

## סוג שינוי
- [x] feat: פיצ'ר חדש

## צ'קליסט
- [x] כל הפלט בעברית (כותרת PR, תיאור, הערות בקוד)
- [x] אין `print()` — רק `logger`
- [x] type hints בכל פונקציה
- [x] בדיקות לפיצ'רים חדשים
- [x] אין `except Exception: pass`
- [x] הודעות שגיאה ברורות בעברית למשתמש
- [x] עובד זהה בוואטסאפ (לא משפיע על טלגרם)

## השפעות / סיכונים
**השפעה חיובית:**
- שיפור חוויית משתמש — ממשק אינט

https://claude.ai/code/session_01A2j7vpSg3KjcVbX6kvS8dT