### PR TITLE
תיקון ולידציה ונורמליזציה של מספרי טלפון בינלאומיים ללא +

### DIFF
--- a/app/core/validation.py
+++ b/app/core/validation.py
@@ -103,6 +103,10 @@ class PhoneNumberValidator:
         if allow_international and ValidationPatterns.PHONE_INTERNATIONAL.match(cleaned):
             return True
 
+        # מספר בינלאומי ללא + (למשל מ-WhatsApp: 15551708949)
+        if allow_international and re.match(r"^[1-9]\d{6,14}$", cleaned):
+            return True
+
         return False
 
     @staticmethod
@@ -124,6 +128,9 @@ class PhoneNumberValidator:
         if cleaned.startswith("0"):
             cleaned = "+972" + cleaned[1:]
         elif cleaned.startswith("972") and not cleaned.startswith("+"):
+            cleaned = "+" + cleaned
+        elif not cleaned.startswith("+"):
+            # מספר בינלאומי ללא + (למשל מ-WhatsApp: 15551708949)
             cleaned = "+" + cleaned
 
         return cleaned

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -31,6 +31,9 @@ class TestPhoneNumberValidator:
         ("+1 (555) 170-8949", True),  # US format with parentheses (Meta test number)
         ("+1(555)1708949", True),  # US format without spaces
         ("+44.20.7946.0958", True),  # UK format with dots
+        # Valid international numbers without + (from WhatsApp/Telegram platforms)
+        ("15551708949", True),  # US without +
+        ("442079460958", True),  # UK without +
         # Invalid numbers
         ("123", False),
         ("abcdefghij", False),
@@ -54,6 +57,10 @@ class TestPhoneNumberValidator:
 
         # International with parentheses (Meta test number)
         assert PhoneNumberValidator.normalize("+1 (555) 170-8949") == "+15551708949"
+
+        # מספר בינלאומי ללא + (כמו שמגיע מ-WhatsApp/Telegram)
+        assert PhoneNumberValidator.normalize("15551708949") == "+15551708949"
+        assert PhoneNumberValidator.normalize("442079460958") == "+442079460958"
 
     @pytest.mark.unit
     def test_mask_phone(self):


### PR DESCRIPTION
הכל נדחף. הנה סיכום השינויים:
app/core/validation.py — שני תיקונים:
validate() (שורה 106) — הוספת תמיכה במספרים בינלאומיים ללא + (pattern ^[1-9]\d{6,14}$). מספר כמו 15551708949 שמגיע מ-WhatsApp עכשיו עובר ולידציה.
normalize() (שורה 128) — הוספת elif not cleaned.startswith("+") שמוסיף + לכל מספר בינלאומי שלא מתחיל ב-0 (ישראלי) או 972. למשל 15551708949 → +15551708949.
tests/test_validation.py — הוספת מקרי בדיקה:
15551708949 (US ללא +) ו-442079460958 (UK ללא +) ב-validate
בדיקות normalize שמוודאות הוספת +
60 בדיקות עברו.


validate() דחה מספרים בינלאומיים שהגיעו בלי + (למשל 15551708949 מ-WhatsApp/Telegram), ו-normalize() לא הוסיף + למספרים לא-ישראליים. זה גרם לחוסר התאמה בין מספרים שנשמרו מהפלטפורמה לבין מספרים שהוזנו בפאנל.

https://claude.ai/code/session_01QEH857frKY8y6doAet2rsb

