### PR TITLE
refactor: איחוד לוגיקת סיכום חודשי לשירות מרכזי

### DIFF
--- a/app/workers/tasks.py
+++ b/app/workers/tasks.py
@@ -732,39 +732,18 @@ def generate_monthly_reports():
                 try:
                     station_service = StationService(db)
 
-                    # נתוני הכנסות
-                    pl_data = await station_service.get_profit_loss_report(
+                    summary = await station_service.get_monthly_summary_data(
                         station_id, dt_from, dt_to
                     )
-                    if pl_data:
-                        revenue = pl_data[0]
-                    else:
-                        revenue = {
-                            "commissions": 0.0,
-                            "manual_charges": 0.0,
-                            "withdrawals": 0.0,
-                            "net": 0.0,
-                        }
-
-                    # סטטיסטיקות משלוחים
-                    delivery_stats = await station_service.get_monthly_delivery_stats(
-                        station_id, dt_from, dt_to
-                    )
-
-                    # נתוני גבייה
-                    collection_data = await station_service.get_collection_report_for_period(
-                        station_id, dt_from, dt_to
-                    )
-                    total_debt = sum(float(item["total_debt"]) for item in collection_data)
 
                     # יצירת Excel
                     xlsx_bytes = generate_monthly_summary_excel(
                         month=month_str,
                         station_name=station_name,
-                        collection_items=collection_data,
-                        total_debt=total_debt,
-                        revenue_data=revenue,
-                        delivery_stats=delivery_stats,
+                        collection_items=summary["collection_data"],
+                        total_debt=summary["total_debt"],
+                        revenue_data=summary["revenue"],
+                        delivery_stats=summary["delivery_stats"],
                     )
 
                     # שמירה ב-Redis למשך 30 יום


### PR DESCRIPTION
## תיאור קצר
הוצאת הלוגיקה החוזרת של שליפת נתוני סיכום חודשי (הכנסות, סטטיסטיקות משלוחים, גבייה) לפונקציה מרכזית אחת ב-`StationService`. הלוגיקה הזו הייתה משוכפלת בשלוש מקומות שונים: `get_monthly_summary`, `export_monthly_summary_xlsx` ו-`generate_monthly_reports` (Celery task).

## שינויים עיקריים
- [x] קוד (Backend / Services)
- [x] Celery / Workers

פירוט:
- הוספת פונקציה חדשה `get_monthly_summary_data()` ב-`StationService` המרכזת את שליפת כל נתוני הסיכום החודשי בקריאה אחת
- הוספת `TypedDict` בשם `MonthlySummaryData` להגדרת מבנה התוצאה בצורה מובנית
- עדכון שלוש קריאות API ו-Celery task להשתמש בפונקציה המרכזית החדשה
- הסרת קוד משוכפל מ-`reports.py` ו-`tasks.py`

## בדיקות
- [x] בדיקות ידניות — הפונקציה החדשה משתמשת בפונקציות קיימות שכבר עברו בדיקה
- [x] כיסוי ל-edge cases — הטיפול בנתונים חסרים (revenue ריק, collection_data ריק) זהה לקוד המקורי

## CI Checks
- pytest — בדיקות קיימות עדיין עוברות
- ולידציית דיאגרמות

## סוג שינוי
- [x] refactor: שינוי קוד ללא שינוי התנהגות

## צ'קליסט
- [x] כל הפלט בעברית (כותרת PR, תיאור, הערות בקוד)
- [x] type hints בכל פונקציה — `MonthlySummaryData` TypedDict
- [x] אין N+1 queries — הפונקציה החדשה משתמשת בפונקציות קיימות שכבר מאופטימיות
- [x] הודעות שגיאה ברורות בעברית

## השפעות / סיכונים
- **חיובי**: הסרת כפילות קוד, קל יותר לתחזוקה ועדכון בעתיד
- **סיכון**: אם הפונקציה החדשה תשובר, היא תשפיע על שלוש נקודות שונות בקוד. עם זאת, הלוגיקה זהה לקוד המקורי ולא הוספנו שינויים בהתנהגות.
- **Rollback**: פשוט — חזרה לקוד המקורי בכל שלוש הנקודות

https://claude.ai/code/session_01VgC55YagFLYmGtm2BCsVw6