### PR TITLE
תיקון: readiness probe לא חוסם תעבורת טלגרם כש-WhatsApp מושבת

### DIFF
--- a/app/domain/services/health_service.py
+++ b/app/domain/services/health_service.py
@@ -21,6 +21,7 @@ logger = get_logger(__name__)
 # סטטוסים אפשריים לתשובת readiness
 _STATUS_HEALTHY = "healthy"
 _STATUS_DEGRADED = "degraded"
+_STATUS_UNHEALTHY = "unhealthy"
 
 _CHECK_OK = "ok"
 
@@ -102,8 +103,13 @@ async def check_readiness() -> dict[str, Any]:
     בדיקת מוכנות מקיפה — בודק את כל התלויות החיצוניות.
 
     מחזיר dict עם סטטוס כללי ופירוט לכל תלות:
-    - status: "healthy" אם הכל תקין, "degraded" אם יש בעיה באחת התלויות
+    - status: "healthy" אם הכל תקין, "degraded" אם יש בעיה בתלות לא קריטית,
+      "unhealthy" אם תלות קריטית לא זמינה
     - db / redis / whatsapp_gateway / celery: "ok" או "error: ..."
+
+    תלויות קריטיות (DB, Redis, Celery) — כשל בהן מחזיר HTTP 503.
+    תלויות לא קריטיות (WhatsApp Gateway) — כשל בהן מחזיר HTTP 200 עם status=degraded.
+    זה מונע מצב שבו WhatsApp מושבת חוסם את כל התעבורה כולל טלגרם.
     """
     db_status = await _check_db()
     redis_status = await _check_redis()
@@ -117,12 +123,26 @@ async def check_readiness() -> dict[str, Any]:
         "celery": celery_status,
     }
 
+    # תלויות קריטיות — כשל בהן = המערכת לא יכולה לשרת בקשות
+    critical_checks = {
+        "db": db_status,
+        "redis": redis_status,
+        "celery": celery_status,
+    }
+    critical_ok = all(v == _CHECK_OK for v in critical_checks.values())
     all_ok = all(v == _CHECK_OK for v in checks.values())
-    overall_status = _STATUS_HEALTHY if all_ok else _STATUS_DEGRADED
+
+    if not critical_ok:
+        overall_status = _STATUS_UNHEALTHY
+    elif not all_ok:
+        overall_status = _STATUS_DEGRADED
+    else:
+        overall_status = _STATUS_HEALTHY
 
     if not all_ok:
         logger.warning(
-            "בדיקת מוכנות — המערכת במצב degraded",
+            "בדיקת מוכנות — המערכת במצב %s",
+            overall_status,
             extra_data=checks,
         )
 

--- a/app/main.py
+++ b/app/main.py
@@ -173,32 +173,49 @@ async def health_check() -> dict[str, str]:
     summary="בדיקת מוכנות (Readiness Probe)",
     description=(
         "בדיקה מקיפה של כל התלויות: DB, Redis, WhatsApp Gateway, Celery broker. "
-        "מחזיר status=healthy אם הכל תקין, או status=degraded עם פירוט השגיאה."
+        "מחזיר status=healthy אם הכל תקין, status=degraded אם תלות לא קריטית "
+        "(WhatsApp) לא זמינה (עדיין HTTP 200), או status=unhealthy עם HTTP 503 "
+        "אם תלות קריטית (DB/Redis/Celery) לא זמינה."
     ),
     responses={
         200: {
-            "description": "כל התלויות תקינות",
+            "description": "תלויות קריטיות תקינות (WhatsApp עשוי להיות מושבת)",
             "content": {
                 "application/json": {
-                    "example": {
-                        "status": "healthy",
-                        "db": "ok",
-                        "redis": "ok",
-                        "whatsapp_gateway": "ok",
-                        "celery": "ok",
+                    "examples": {
+                        "healthy": {
+                            "summary": "הכל תקין",
+                            "value": {
+                                "status": "healthy",
+                                "db": "ok",
+                                "redis": "ok",
+                                "whatsapp_gateway": "ok",
+                                "celery": "ok",
+                            },
+                        },
+                        "degraded": {
+                            "summary": "WhatsApp מושבת — טלגרם עדיין עובד",
+                            "value": {
+                                "status": "degraded",
+                                "db": "ok",
+                                "redis": "ok",
+                                "whatsapp_gateway": "error: whatsapp_disconnected",
+                                "celery": "ok",
+                            },
+                        },
                     }
                 }
             },
         },
         503: {
-            "description": "לפחות תלות אחת לא זמינה",
+            "description": "תלות קריטית לא זמינה — המערכת לא יכולה לשרת בקשות",
             "content": {
                 "application/json": {
                     "example": {
-                        "status": "degraded",
-                        "db": "ok",
+                        "status": "unhealthy",
+                        "db": "error: db_unavailable",
                         "redis": "ok",
-                        "whatsapp_gateway": "error: 404",
+                        "whatsapp_gateway": "ok",
                         "celery": "ok",
                     }
                 }
@@ -214,7 +231,9 @@ async def readiness_check() -> dict[str, str]:
     from app.domain.services.health_service import check_readiness
 
     result = await check_readiness()
-    status_code = 200 if result["status"] == "healthy" else 503
+    # רק כשל בתלות קריטית (DB/Redis/Celery) מחזיר 503.
+    # WhatsApp מושבת = degraded אבל עדיין HTTP 200 — כדי לא לחסום תעבורת טלגרם.
+    status_code = 503 if result["status"] == "unhealthy" else 200
     return JSONResponse(content=result, status_code=status_code)
 
 

--- a/tests/test_health_check.py
+++ b/tests/test_health_check.py
@@ -63,7 +63,7 @@ class TestReadinessProbe:
 
     @pytest.mark.unit
     async def test_readiness_db_down(self, test_client: httpx.AsyncClient) -> None:
-        """כש-DB לא זמין — status=degraded ו-HTTP 503."""
+        """כש-DB לא זמין — status=unhealthy ו-HTTP 503."""
         with patch(
             "app.domain.services.health_service._check_db",
             new_callable=AsyncMock,
@@ -85,7 +85,7 @@ class TestReadinessProbe:
 
         assert response.status_code == 503
         data = response.json()
-        assert data["status"] == "degraded"
+        assert data["status"] == "unhealthy"
         assert data["db"] == "error: db_unavailable"
         assert data["redis"] == "ok"
 
@@ -93,7 +93,7 @@ class TestReadinessProbe:
     async def test_readiness_whatsapp_gateway_down(
         self, test_client: httpx.AsyncClient
     ) -> None:
-        """כש-WhatsApp Gateway לא זמין — status=degraded ו-HTTP 503."""
+        """כש-WhatsApp Gateway לא זמין — status=degraded אבל HTTP 200 (תלות לא קריטית)."""
         with patch(
             "app.domain.services.health_service._check_db",
             new_callable=AsyncMock,
@@ -113,17 +113,17 @@ class TestReadinessProbe:
         ):
             response = await test_client.get("/health/ready")
 
-        assert response.status_code == 503
+        assert response.status_code == 200
         data = response.json()
         assert data["status"] == "degraded"
         assert data["whatsapp_gateway"] == "error: whatsapp_unavailable"
         assert data["db"] == "ok"
 
     @pytest.mark.unit
-    async def test_readiness_multiple_failures(
+    async def test_readiness_multiple_critical_failures(
         self, test_client: httpx.AsyncClient
     ) -> None:
-        """כשכמה תלויות נכשלות — status=degraded ופירוט לכל תלות."""
+        """כשכמה תלויות קריטיות נכשלות — status=unhealthy ו-HTTP 503."""
         with patch(
             "app.domain.services.health_service._check_db",
             new_callable=AsyncMock,
@@ -145,7 +145,7 @@ class TestReadinessProbe:
 
         assert response.status_code == 503
         data = response.json()
-        assert data["status"] == "degraded"
+        assert data["status"] == "unhealthy"
         assert data["db"] == "error: db_unavailable"
         assert data["redis"] == "error: redis_unavailable"
         assert data["whatsapp_gateway"] == "ok"
@@ -155,7 +155,7 @@ class TestReadinessProbe:
     async def test_readiness_celery_broker_down(
         self, test_client: httpx.AsyncClient
     ) -> None:
-        """כש-Celery broker לא זמין — status=degraded."""
+        """כש-Celery broker לא זמין — status=unhealthy ו-HTTP 503 (תלות קריטית)."""
         with patch(
             "app.domain.services.health_service._check_db",
             new_callable=AsyncMock,
@@ -177,8 +177,38 @@ class TestReadinessProbe:
 
         assert response.status_code == 503
         data = response.json()
-        assert data["status"] == "degraded"
+        assert data["status"] == "unhealthy"
         assert data["celery"] == "error: celery_unavailable"
+
+    @pytest.mark.unit
+    async def test_readiness_whatsapp_and_critical_down(
+        self, test_client: httpx.AsyncClient
+    ) -> None:
+        """כש-WhatsApp וגם DB לא זמינים — status=unhealthy ו-HTTP 503 (בגלל DB)."""
+        with patch(
+            "app.domain.services.health_service._check_db",
+            new_callable=AsyncMock,
+            return_value="error: db_unavailable",
+        ), patch(
+            "app.domain.services.health_service._check_redis",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ), patch(
+            "app.domain.services.health_service._check_whatsapp_gateway",
+            new_callable=AsyncMock,
+            return_value="error: whatsapp_unavailable",
+        ), patch(
+            "app.domain.services.health_service._check_celery",
+            new_callable=AsyncMock,
+            return_value="ok",
+        ):
+            response = await test_client.get("/health/ready")
+
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "unhealthy"
+        assert data["db"] == "error: db_unavailable"
+        assert data["whatsapp_gateway"] == "error: whatsapp_unavailable"
 
 
 # ============================================================================


### PR DESCRIPTION
הפרדה בין תלויות קריטיות (DB, Redis, Celery) לתלויות לא קריטיות (WhatsApp Gateway). רק כשל בתלות קריטית מחזיר HTTP 503 — כשל ב-WhatsApp מחזיר HTTP 200 עם status=degraded. זה מונע מצב שבו Render חוסם את כל התעבורה (כולל webhooks של טלגרם) בגלל WhatsApp מנותק.

https://claude.ai/code/session_01Y4X1uCjd2kcVmwvgGRh6My

הושלם. הנה סיכום מה שונה:

**הבעיה:** ה-readiness probe (`/health/ready`) היה מחזיר HTTP 503 כש-WhatsApp Gateway מנותק. Render רואה 503 → מפסיק לנתב תעבורה → webhooks של טלגרם לא מגיעים → הבוט "לא מגיב".

**הפתרון:** חילקתי את התלויות לשתי רמות:
- **קריטיות** (DB, Redis, Celery) — כשל = HTTP 503 (`status: "unhealthy"`)
- **לא קריטיות** (WhatsApp Gateway) — כשל = HTTP 200 (`status: "degraded"`)

ככה כש-WhatsApp מושבת, Render ממשיך לנתב תעבורה לשרת, וטלגרם עובד כרגיל.

**אחרי שתעשה דיפלוי:**
1. בדוק `curl https://<domain>/health/ready` — צריך להחזיר 200 עם `"status": "degraded"` (בגלל WhatsApp מנותק)
2. שלח `/start` לבוט בטלגרם — צריך להגיב עכשיו