### PR TITLE
תיקון: כשלון placeholder לניקוי reply keyboard כבר לא מונע שליחת הודעה

### DIFF
--- a/app/api/webhooks/telegram.py
+++ b/app/api/webhooks/telegram.py
@@ -838,17 +838,17 @@ async def send_telegram_message(
 
         return True
 
-    try:
-        inline_keyboard: list[list[dict]] | None = None
-        if keyboard:
-            inline_keyboard = await _build_inline_keyboard(keyboard)
+    inline_keyboard: list[list[dict]] | None = None
+    if keyboard:
+        inline_keyboard = await _build_inline_keyboard(keyboard)
 
-        # --- ניקוי reply keyboard ישן (פעם אחת לכל chat, רק כשיש כפתורים) ---
-        if keyboard and not await _was_reply_keyboard_cleared(chat_id):
-            placeholder_payload = {
+    # --- ניקוי reply keyboard ישן (פעם אחת לכל chat, רק כשיש כפתורים) ---
+    # best-effort: כשלון כאן לא ימנע שליחת ההודעה האמיתית
+    if keyboard and not await _was_reply_keyboard_cleared(chat_id):
+        try:
+            placeholder_payload: dict = {
                 "chat_id": chat_id,
-                "text": "\u200b",
-                "parse_mode": "HTML",
+                "text": ".",
                 "reply_markup": {"remove_keyboard": True},
             }
 
@@ -867,8 +867,14 @@ async def send_telegram_message(
                     await _delete_message(int(placeholder_message_id))
                 except Exception:
                     pass
+        except Exception as e:
+            logger.warning(
+                "כשלון בניקוי reply keyboard (best-effort, ממשיך לשליחה)",
+                extra_data={"chat_id": chat_id, "error": str(e)},
+            )
 
-        # --- שליחה ---
+    # --- שליחה ---
+    try:
         payload: dict = {
             "chat_id": chat_id,
             "text": text,


### PR DESCRIPTION
הבאג: ה-placeholder ששלח \u200b (zero-width space) עם parse_mode=HTML נדחה על ידי Telegram עם 400. כיוון שה-try/except עטף גם את ה-placeholder וגם את ההודעה האמיתית — ההודעה אף פעם לא נשלחה.

תיקונים:
1. הפרדת try/except — כשלון placeholder לא מונע שליחת ההודעה האמיתית
2. שינוי טקסט placeholder מ-\u200b ל-"." (מתמחק מיד אחרי)
3. הסרת parse_mode מהplaceholder (לא נדרש)
4. הורדת רמת לוג placeholder ל-warning (best-effort)

https://claude.ai/code/session_01Y4X1uCjd2kcVmwvgGRh6My

**סיכום הבאג שתוקן:**

ב-`send_telegram_message` היה באג קריטי — ה-placeholder שמנקה reply keyboard ישן (שלח `\u200b` zero-width space) נכשל עם 400 מ-Telegram. כיוון ש-`try/except` אחד עטף **גם** את ה-placeholder **וגם** את ההודעה האמיתית, כשלון ה-placeholder מנע שליחת ההודעה לחלוטין.

**מה תוקן:**
1. **הפרדת try/except** — כשלון placeholder (best-effort) לא חוסם את ההודעה האמיתית
2. **שינוי טקסט** מ-`\u200b` ל-`"."` — Telegram דוחה zero-width space עם HTML parsing
3. **הסרת `parse_mode`** מה-placeholder — לא נדרש לטקסט פשוט