### PR TITLE
תיקון: כשל Redis ב-cooldown מחזיר שגיאה ידידותית — לא 500 גנרי

### DIFF
--- a/app/api/routes/panel/auth.py
+++ b/app/api/routes/panel/auth.py
@@ -150,7 +150,23 @@ async def request_otp(
 ) -> ActionResponse:
     """בקשת קוד כניסה — תשובה גנרית למניעת user-enumeration"""
     # Rate limiting אטומי לפי טלפון — SET NX EX, לפני כל בדיקת קיום (מונע enumeration)
-    if not await try_set_otp_cooldown_by_phone(data.phone_number):
+    try:
+        cooldown_ok = await try_set_otp_cooldown_by_phone(data.phone_number)
+    except Exception as e:
+        logger.error(
+            "כשלון בבדיקת cooldown ב-Redis — לא ניתן לשלוח OTP",
+            extra_data={
+                "phone": PhoneNumberValidator.mask(data.phone_number),
+                "error": str(e),
+            },
+            exc_info=True,
+        )
+        return ActionResponse(
+            success=False,
+            message="אירעה שגיאה בשליחת קוד הכניסה, נסה שוב מאוחר יותר",
+        )
+
+    if not cooldown_ok:
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail="נא להמתין לפחות דקה בין בקשות קוד כניסה",

--- a/tests/test_panel_auth.py
+++ b/tests/test_panel_auth.py
@@ -628,3 +628,37 @@ class TestOTPDelivery:
         )
         msg = result.scalar_one_or_none()
         assert msg is None, "הודעת outbox נשמרה למרות כשל Redis — OTP לא ניתן לאימות"
+
+    @pytest.mark.asyncio
+    async def test_redis_cooldown_failure_returns_error_not_500(
+        self, test_client, user_factory, db_session,
+    ):
+        """כשל Redis בבדיקת cooldown מחזיר שגיאה ידידותית — לא 500 גנרי"""
+        user = await user_factory(
+            phone_number="+972501234567",
+            name="בעל תחנה cooldown כשל",
+            role=UserRole.STATION_OWNER,
+            platform="telegram",
+            telegram_chat_id="444555666",
+        )
+        station = Station(name="תחנה", owner_id=user.id)
+        db_session.add(station)
+        await db_session.flush()
+        wallet = StationWallet(station_id=station.id)
+        db_session.add(wallet)
+        await db_session.commit()
+
+        with patch(
+            "app.api.routes.panel.auth.try_set_otp_cooldown_by_phone",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("Redis connection refused"),
+        ):
+            response = await test_client.post("/api/panel/auth/request-otp", json={
+                "phone_number": "0501234567",
+            })
+
+            # לא 500 — שגיאה ידידותית
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is False
+            assert "שגיאה" in data["message"]


### PR DESCRIPTION
try_set_otp_cooldown_by_phone לא היה עטוף ב-try/except. כש-Redis לא זמין, הפונקציה זורקת exception לא נתפס → 500 גנרי בלי שום לוג ספציפי ל-OTP. תוצאה: "אין כלום בלוגים ולא נשלח קוד".

עכשיו:
- כשל Redis ב-cooldown → לוג שגיאה ברור + תגובת success=False
- לא 500 גנרי — המשתמש מקבל הודעה בעברית
- בדיקה חדשה: test_redis_cooldown_failure_returns_error_not_500

https://claude.ai/code/session_01K4iTrhMWa12gEAZYZnc96E

הנה מה שנמצא ותוקן:

**הבאג האמיתי:** `try_set_otp_cooldown_by_phone(data.phone_number)` בשורה הראשונה של `request_otp` קורא ל-Redis **בלי try/except**. כש-Redis לא זמין:
1. נזרק `ConnectionError` לא נתפס
2. FastAPI מחזיר 500 גנרי
3. **אף שורת לוג ספציפית ל-OTP לא נכתבת** — הפונקציה מתפוצצת לפני שמגיעים ל-`store_otp`, ל-outbox, או לכל `logger.info/error` אחר
4. המשתמש בפרונט רואה שגיאה לא מובנת, ולא נשלח קוד

**התיקון:** עטפתי את הקריאה ב-try/except — כשל Redis מחזיר `success=False` עם הודעה בעברית ולוג שגיאה ברור שכולל את מספר הטלפון (ממוסך) ואת פרטי השגיאה.