### PR TITLE
תיקון שגיאת TypeScript ב-MultiStationPage: הוספת type guard ל-accesso…

### DIFF
--- a/frontend/src/pages/MultiStationPage.tsx
+++ b/frontend/src/pages/MultiStationPage.tsx
@@ -157,7 +157,7 @@ export default function MultiStationPage() {
 
   // הוספת badge לתחנה הנוכחית
   const stationsWithCurrent = columns.map((col) => {
-    if (col.accessorKey === "station_name") {
+    if ("accessorKey" in col && col.accessorKey === "station_name") {
       return {
         ...col,
         cell: ({ row }: { row: { original: StationSummary } }) => (


### PR DESCRIPTION
…rKey

ColumnDef הוא union type ולא כל הוריאנטים שלו מכילים accessorKey. הוספת בדיקת "accessorKey" in col לפני גישה לשדה כדי לעבור את tsc --noEmit.

https://claude.ai/code/session_014DqHbcUSa5zfWbPWEwnyTG

הבעיה תוקנה. `ColumnDef` של tanstack/react-table הוא union type — לא כל הוריאנטים מכילים את השדה `accessorKey`. הוספתי type guard (`"accessorKey" in col`) בשורה 160 לפני הגישה לשדה, מה שמסיר את שגיאת ה-TS2339 שגרמה לבילד ליפול.