### PR TITLE
הוסף ולידציה ונירמול מספר טלפון בחיפוש משתמש

### DIFF
--- a/app/api/routes/users.py
+++ b/app/api/routes/users.py
@@ -176,8 +176,11 @@ async def get_user_by_phone(
     db: AsyncSession = Depends(get_db),
 ):
     """חיפוש משתמש לפי מספר טלפון — מוגן למניעת enumeration"""
+    if not PhoneNumberValidator.validate(phone_number):
+        raise HTTPException(status_code=422, detail="מספר טלפון לא תקין")
+    normalized_phone = PhoneNumberValidator.normalize(phone_number)
     result = await db.execute(
-        select(User).where(User.phone_number == phone_number)
+        select(User).where(User.phone_number == normalized_phone)
     )
     user = result.scalar_one_or_none()
     if not user:

--- a/tests/test_api_users.py
+++ b/tests/test_api_users.py
@@ -99,6 +99,40 @@ class TestUserAPI:
         assert data["phone_number"] == sample_sender.phone_number
 
     @pytest.mark.integration
+    async def test_get_user_by_phone_unnormalized(
+        self,
+        test_client: AsyncClient,
+        sample_sender: User
+    ):
+        """חיפוש משתמש לפי טלפון לא מנורמל — צריך למצוא אותו"""
+        # sample_sender.phone_number הוא בפורמט +972...
+        # נשלח בפורמט מקומי (0...) ונוודא שהנירמול עובד
+        local_phone = "0" + sample_sender.phone_number[4:]  # +972X -> 0X
+        with patch.object(settings, "ADMIN_API_KEY", "test-key"):
+            response = await test_client.get(
+                f"/api/users/phone/{local_phone}",
+                headers={"X-Admin-API-Key": "test-key"},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["phone_number"] == sample_sender.phone_number
+
+    @pytest.mark.integration
+    async def test_get_user_by_phone_invalid(
+        self,
+        test_client: AsyncClient,
+    ):
+        """חיפוש לפי טלפון לא תקין — מחזיר 422"""
+        with patch.object(settings, "ADMIN_API_KEY", "test-key"):
+            response = await test_client.get(
+                "/api/users/phone/invalid",
+                headers={"X-Admin-API-Key": "test-key"},
+            )
+
+        assert response.status_code == 422
+
+    @pytest.mark.integration
     async def test_get_couriers(
         self,
         test_client: AsyncClient,


### PR DESCRIPTION
## תיאור קצר
הוספת ולידציה ונירמול מספר טלפון בנקודת הקצה `/api/users/phone/{phone_number}`. כעת המערכת מוודאת שמספר הטלפון תקין ומנרמלת אותו לפורמט סטנדרטי לפני החיפוש, מה שמאפשר חיפוש עם מספרים בפורמטים שונים (למשל: `0501234567` ו-`+972501234567`).

## שינויים עיקריים
- [x] קוד (Backend / Services)

פירוט:
- הוספת ולידציה של מספר טלפון בפונקציה `get_user_by_phone` — מחזירה 422 אם המספר לא תקין
- נירמול מספר הטלפון לפורמט סטנדרטי לפני החיפוש בבסיס הנתונים
- הוספת שתי בדיקות אינטגרציה: בדיקה לחיפוש עם מספר טלפון לא מנורמל, ובדיקה לדחיית מספר טלפון לא תקין

## בדיקות
- [x] Unit tests — עוברים
- [x] בדיקות אינטגרציה חדשות:
  - `test_get_user_by_phone_unnormalized` — מוודא שחיפוש עם פורמט מקומי (0...) מוצא את המשתמש
  - `test_get_user_by_phone_invalid` — מוודא שמספר טלפון לא תקין מחזיר 422

## סוג שינוי
- [x] feat: פיצ'ר חדש

## צ'קליסט
- [x] כל הפלט בעברית (כותרת PR, תיאור, הודעות commit, הערות בקוד)
- [x] כל קלט עובר ולידציה
- [x] type hints בכל פונקציה
- [x] בדיקות לפיצ'רים חדשים
- [x] בדיקת authorization לפני כל פעולה (קיימת בקוד הקודם)
- [x] הודעות שגיאה ברורות בעברית למשתמש

## השפעות / סיכונים
- שינוי זה משפר את חוויית המשתמש בחיפוש משתמשים לפי טלפון
- אין השפעה על ביצועים או אבטחה
- תאימות לאחור: משתמשים שכבר שולחים מספרים בפורמט מנורמל ימשיכו לעבוד כרגיל

https://claude.ai/code/session_018GcRiHjeRQ84rY426hXmk8