### PR TITLE
תיקון: דילוג על בדיקת סדרן בניתוב תפריט כשאדמין מחליף תפקיד

### DIFF
--- a/app/api/webhooks/telegram.py
+++ b/app/api/webhooks/telegram.py
@@ -1184,11 +1184,21 @@ async def _route_to_role_menu(
     """
     # שמירת admin context לפני ניתוב (force_state מוחק context)
     admin_keys = await _save_admin_context(user.id, state_manager, "telegram")
+    is_admin_impersonating = bool(
+        admin_keys and admin_keys.get("original_role") == "admin"
+    )
+    # כשאדמין מחליף תפקיד, דילוג על בדיקת סדרן אלא אם ביקש תפקיד סדרן —
+    # אחרת שיוך סדרן אמיתי ב-DB ינתב תמיד לתפריט סדרן במקום לתפקיד המבוקש
+    skip_dispatcher = is_admin_impersonating and admin_keys.get(
+        "admin_target_role"
+    ) != "dispatcher"
 
-    response, new_state = await _route_to_role_menu_inner(user, db, state_manager)
+    response, new_state = await _route_to_role_menu_inner(
+        user, db, state_manager, skip_dispatcher_check=skip_dispatcher
+    )
 
     # שחזור admin context והוספת כפתור חזרה
-    if admin_keys and admin_keys.get("original_role") == "admin":
+    if is_admin_impersonating:
         await _restore_admin_context(
             user.id, state_manager, new_state, admin_keys, "telegram"
         )
@@ -1201,6 +1211,8 @@ async def _route_to_role_menu_inner(
     user: User,
     db: AsyncSession,
     state_manager: StateManager,
+    *,
+    skip_dispatcher_check: bool = False,
 ) -> tuple[MessageResponse, str]:
     """ניתוב פנימי לתפריט לפי תפקיד — ללא טיפול ב-admin context"""
     if user.role == UserRole.COURIER:
@@ -1229,13 +1241,14 @@ async def _route_to_role_menu_inner(
         await session_service.touch_session(user.id)
 
         # סשן 9: בדיקה אם הנהג הוא גם סדרן פעיל בתחנה
-        dispatcher_station = await _get_dispatcher_station(user, db)
-        if dispatcher_station is not None:
-            await state_manager.force_state(
-                user.id, "telegram", DispatcherState.MENU.value, context={}
-            )
-            handler = DispatcherStateHandler(db, dispatcher_station.id)
-            return await handler.handle_message(user, "תפריט", None)
+        if not skip_dispatcher_check:
+            dispatcher_station = await _get_dispatcher_station(user, db)
+            if dispatcher_station is not None:
+                await state_manager.force_state(
+                    user.id, "telegram", DispatcherState.MENU.value, context={}
+                )
+                handler = DispatcherStateHandler(db, dispatcher_station.id)
+                return await handler.handle_message(user, "תפריט", None)
 
         # נהג רשום → ישירות לתפריט; לא רשום → _handle_initial ינתב לרישום
         await state_manager.force_state(
@@ -1258,13 +1271,14 @@ async def _route_to_role_menu_inner(
 
     if user.role == UserRole.SENDER:
         # בדיקה אם המשתמש הוא סדרן פעיל — סדרנים שאינם שליחים נכנסים ישירות לתפריט סדרן
-        dispatcher_station = await _get_dispatcher_station(user, db)
-        if dispatcher_station is not None:
-            await state_manager.force_state(
-                user.id, "telegram", DispatcherState.MENU.value, context={}
-            )
-            handler = DispatcherStateHandler(db, dispatcher_station.id)
-            return await handler.handle_message(user, "תפריט", None)
+        if not skip_dispatcher_check:
+            dispatcher_station = await _get_dispatcher_station(user, db)
+            if dispatcher_station is not None:
+                await state_manager.force_state(
+                    user.id, "telegram", DispatcherState.MENU.value, context={}
+                )
+                handler = DispatcherStateHandler(db, dispatcher_station.id)
+                return await handler.handle_message(user, "תפריט", None)
 
         return await _sender_fallback(user, db, state_manager)
 

--- a/app/api/webhooks/whatsapp.py
+++ b/app/api/webhooks/whatsapp.py
@@ -856,11 +856,20 @@ async def _route_to_role_menu_wa(
     """
     # שמירת admin context לפני ניתוב
     admin_keys = await _save_admin_context_wa(user.id, state_manager, "whatsapp")
+    is_admin_impersonating = bool(
+        admin_keys and admin_keys.get("original_role") == "admin"
+    )
+    # כשאדמין מחליף תפקיד, דילוג על בדיקת סדרן אלא אם ביקש תפקיד סדרן
+    skip_dispatcher = is_admin_impersonating and admin_keys.get(
+        "admin_target_role"
+    ) != "dispatcher"
 
-    response, new_state = await _route_to_role_menu_wa_inner(user, db, state_manager)
+    response, new_state = await _route_to_role_menu_wa_inner(
+        user, db, state_manager, skip_dispatcher_check=skip_dispatcher
+    )
 
     # שחזור admin context והוספת כפתור חזרה
-    if admin_keys and admin_keys.get("original_role") == "admin":
+    if is_admin_impersonating:
         await _restore_admin_context_wa(
             user.id, state_manager, new_state, admin_keys, "whatsapp"
         )
@@ -873,6 +882,8 @@ async def _route_to_role_menu_wa_inner(
     user: User,
     db: AsyncSession,
     state_manager: StateManager,
+    *,
+    skip_dispatcher_check: bool = False,
 ) -> tuple:
     """ניתוב פנימי לתפריט לפי תפקיד — ללא טיפול ב-admin context (WhatsApp)"""
     if user.role == UserRole.COURIER:
@@ -912,16 +923,17 @@ async def _route_to_role_menu_wa_inner(
         await session_service.touch_session(user.id)
 
         # סשן 9: בדיקה אם הנהג הוא גם סדרן פעיל בתחנה
-        from app.domain.services.station_service import StationService
+        if not skip_dispatcher_check:
+            from app.domain.services.station_service import StationService
 
-        station_service = StationService(db)
-        dispatcher_station = await station_service.get_dispatcher_station(user.id)
-        if dispatcher_station:
-            await state_manager.force_state(
-                user.id, "whatsapp", DispatcherState.MENU.value, context={}
-            )
-            handler = DispatcherStateHandler(db, dispatcher_station.id, platform="whatsapp")
-            return await handler.handle_message(user, "תפריט", None)
+            station_service = StationService(db)
+            dispatcher_station = await station_service.get_dispatcher_station(user.id)
+            if dispatcher_station:
+                await state_manager.force_state(
+                    user.id, "whatsapp", DispatcherState.MENU.value, context={}
+                )
+                handler = DispatcherStateHandler(db, dispatcher_station.id, platform="whatsapp")
+                return await handler.handle_message(user, "תפריט", None)
 
         await state_manager.force_state(
             user.id, "whatsapp", DriverState.INITIAL.value, context={}
@@ -945,16 +957,17 @@ async def _route_to_role_menu_wa_inner(
 
     if user.role == UserRole.SENDER:
         # בדיקה אם המשתמש הוא סדרן פעיל — סדרנים שאינם שליחים נכנסים ישירות לתפריט סדרן
-        from app.domain.services.station_service import StationService
+        if not skip_dispatcher_check:
+            from app.domain.services.station_service import StationService
 
-        station_service = StationService(db)
-        dispatcher_station = await station_service.get_dispatcher_station(user.id)
-        if dispatcher_station:
-            await state_manager.force_state(
-                user.id, "whatsapp", DispatcherState.MENU.value, context={}
-            )
-            handler = DispatcherStateHandler(db, dispatcher_station.id, platform="whatsapp")
-            return await handler.handle_message(user, "תפריט", None)
+            station_service = StationService(db)
+            dispatcher_station = await station_service.get_dispatcher_station(user.id)
+            if dispatcher_station:
+                await state_manager.force_state(
+                    user.id, "whatsapp", DispatcherState.MENU.value, context={}
+                )
+                handler = DispatcherStateHandler(db, dispatcher_station.id, platform="whatsapp")
+                return await handler.handle_message(user, "תפריט", None)
 
         return await _sender_fallback_wa(user, db, state_manager)
 


### PR DESCRIPTION
כשאדמין מחליף תפקיד לשולח/נהג, _route_to_role_menu_inner בודק get_dispatcher_station ומנתב לתפריט סדרן אם יש שיוך סדרן פעיל ב-DB. זה גורם לאדמין לראות תמיד תפריט סדרן במקום התפקיד שביקש.

התיקון: העברת skip_dispatcher_check=True ל-_route_to_role_menu_inner כשהקונטקסט מכיל admin_target_role שאינו "dispatcher". מתקן בשלושת קבצי ה-webhook: telegram.py, whatsapp.py (+ cloud).

https://claude.ai/code/session_01Ku5DW5AUAUMA4qcL42Hocv

<!--
תבנית PR לפרויקט Shipment Bot.
חובה למלא בעברית — כותרת, תיאור, סיכום, הכל בעברית.
ראו CLAUDE.md > "כללים כלליים" ו-"צ'קליסט לפני PR".
-->

## תיאור קצר
<!-- מה שיניתם ולמה? 2-3 משפטים -->


## שינויים עיקריים
<!-- סמנו את התחומים הרלוונטיים ופרטו -->
- [ ] קוד (Backend / Services)
- [ ] בוט טלגרם
- [ ] בוט וואטסאפ
- [ ] מכונת מצבים (State Machine)
- [ ] מסד נתונים / מיגרציות
- [ ] Celery / Workers
- [ ] תיעוד
- [ ] DevOps / CI/CD

פירוט:
-
-

## בדיקות
<!-- איך בדקתם? מה עבר? מה נשאר? -->
- [ ] Unit tests — עוברים
- [ ] בדיקות ידניות
- [ ] כיסוי ל-edge cases

## CI Checks
- ולידציית דיאגרמות (`--check`)
- pytest

## סוג שינוי
- [ ] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית / CI
- [ ] breaking change: שינוי שובר תאימות

## צ'קליסט
<!-- מבוסס על CLAUDE.md > "צ'קליסט לפני PR" ו-"אסור!" -->
- [ ] כל הפלט בעברית (כותרת PR, תיאור, הודעות commit, הערות בקוד)
- [ ] אין `print()` — רק `logger`
- [ ] מספרי טלפון מוסתרים בלוגים (`PhoneNumberValidator.mask()`)
- [ ] כל קלט עובר ולידציה
- [ ] קריאות API חיצוני עם Circuit Breaker
- [ ] type hints בכל פונקציה
- [ ] endpoints עם תיעוד OpenAPI
- [ ] בדיקות לפיצ'רים חדשים
- [ ] אין `except Exception: pass`
- [ ] בדיקת authorization לפני כל פעולה
- [ ] ולידציית סטטוס לפני מעבר סטטוס
- [ ] אין N+1 queries
- [ ] בדיקת concurrency — מה קורה בפעולה מקבילית?
- [ ] הודעות שגיאה ברורות בעברית למשתמש
- [ ] מספיק לוגים לדיבאג בפרודקשן
- [ ] אם דו-פלטפורמי — עובד זהה בטלגרם ובוואטסאפ

## השפעות / סיכונים
<!-- השפעה על פרודקשן, ביצועים, אבטחה? תוכנית rollback? -->


## קישורים
- Issue: #
