### PR TITLE
תיקון: fallback לזיהוי אדמין לפי TELEGRAM_ADMIN_CHAT_IDS כשה-context אבד

### DIFF
--- a/app/api/webhooks/telegram.py
+++ b/app/api/webhooks/telegram.py
@@ -1962,7 +1962,7 @@ async def telegram_webhook(
                 # fallback: context אבד — מזהים לפי TELEGRAM_ADMIN_CHAT_IDS
                 _is_admin_by_id = (
                     not _is_admin_ctx
-                    and _is_telegram_admin_id(str(user.id))
+                    and _is_telegram_admin_id(telegram_user_id)
                 )
                 if _is_admin_ctx or _is_admin_by_id:
                     if _is_admin_by_id:
@@ -2060,7 +2060,7 @@ async def telegram_webhook(
         _is_admin_by_id = (
             not _is_admin_ctx
             and user.role != UserRole.ADMIN
-            and _is_telegram_admin_id(str(user.id))
+            and _is_telegram_admin_id(telegram_user_id)
         )
         if _is_admin_ctx or _is_admin_by_id:
             if _is_admin_by_id:
@@ -2294,7 +2294,7 @@ async def telegram_webhook(
                     )
                 if (
                     (_dm_admin_keys and _dm_admin_keys.get("original_role") == "admin")
-                    or _is_telegram_admin_id(str(user.id))
+                    or _is_telegram_admin_id(telegram_user_id)
                 ):
                     _inject_admin_return_button(response)
                 _queue_response_send(background_tasks, send_chat_id, response)
@@ -2349,7 +2349,7 @@ async def telegram_webhook(
             _disp_ctx = await state_manager.get_context(user.id, "telegram")
             if (
                 _disp_ctx.get("original_role") == "admin"
-                or _is_telegram_admin_id(str(user.id))
+                or _is_telegram_admin_id(telegram_user_id)
             ):
                 _inject_admin_return_button(response)
             _queue_response_send(background_tasks, send_chat_id, response)
@@ -2388,7 +2388,7 @@ async def telegram_webhook(
         _courier_ctx = await state_manager.get_context(user.id, "telegram")
         if (
             _courier_ctx.get("original_role") == "admin"
-            or _is_telegram_admin_id(str(user.id))
+            or _is_telegram_admin_id(telegram_user_id)
         ):
             _inject_admin_return_button(response)
         _queue_response_send(background_tasks, send_chat_id, response)
@@ -2430,7 +2430,7 @@ async def telegram_webhook(
             _driver_ctx = await state_manager.get_context(user.id, "telegram")
             if (
                 _driver_ctx.get("original_role") == "admin"
-                or _is_telegram_admin_id(str(user.id))
+                or _is_telegram_admin_id(telegram_user_id)
             ):
                 _inject_admin_return_button(response)
         _queue_response_send(background_tasks, send_chat_id, response)
@@ -2484,7 +2484,7 @@ async def telegram_webhook(
             _sender_ctx = await state_manager.get_context(user.id, "telegram")
             if (
                 _sender_ctx.get("original_role") == "admin"
-                or _is_telegram_admin_id(str(user.id))
+                or _is_telegram_admin_id(telegram_user_id)
             ):
                 _inject_admin_return_button(response)
             _queue_response_send(background_tasks, send_chat_id, response)
@@ -2508,7 +2508,7 @@ async def telegram_webhook(
             _sender_ctx2 = await state_manager.get_context(user.id, "telegram")
             if (
                 _sender_ctx2.get("original_role") == "admin"
-                or _is_telegram_admin_id(str(user.id))
+                or _is_telegram_admin_id(telegram_user_id)
             ):
                 _inject_admin_return_button(response)
             _queue_response_send(background_tasks, send_chat_id, response)


### PR DESCRIPTION
כשאדמין מחליף תפקיד ו-admin context נמחק (למשל דרך force_state בזרימת הצטרפות כשליח), אין דרך לחזור לתפריט אדמין.

שינויים:
- הוספת _is_telegram_admin_id() — בודק אם telegram_user_id שייך לאדמין
- fallback ב-"חזרה לאדמין", "#", "/start" — אם context ריק, מזהה אדמין לפי ID
- fallback בהזרקת כפתור "חזרה לאדמין" — כל handler (שליח, סדרן, נהג, שולח) מזריק כפתור גם אם admin context אבד

https://claude.ai/code/session_01CW3HrLZNFgBexeobQxe5Sk

<!--
תבנית PR לפרויקט Shipment Bot.
חובה למלא בעברית — כותרת, תיאור, סיכום, הכל בעברית.
ראו CLAUDE.md > "כללים כלליים" ו-"צ'קליסט לפני PR".
-->

## תיאור קצר
<!-- מה שיניתם ולמה? 2-3 משפטים -->


## שינויים עיקריים
<!-- סמנו את התחומים הרלוונטיים ופרטו -->
- [ ] קוד (Backend / Services)
- [ ] בוט טלגרם
- [ ] בוט וואטסאפ
- [ ] מכונת מצבים (State Machine)
- [ ] מסד נתונים / מיגרציות
- [ ] Celery / Workers
- [ ] תיעוד
- [ ] DevOps / CI/CD

פירוט:
-
-

## בדיקות
<!-- איך בדקתם? מה עבר? מה נשאר? -->
- [ ] Unit tests — עוברים
- [ ] בדיקות ידניות
- [ ] כיסוי ל-edge cases

## CI Checks
- ולידציית דיאגרמות (`--check`)
- pytest

## סוג שינוי
- [ ] feat: פיצ'ר חדש
- [ ] fix: תיקון באג
- [ ] docs: שינוי תיעוד בלבד
- [ ] refactor: שינוי קוד ללא שינוי התנהגות
- [ ] perf: שיפור ביצועים
- [ ] chore/ci: תשתית / CI
- [ ] breaking change: שינוי שובר תאימות

## צ'קליסט
<!-- מבוסס על CLAUDE.md > "צ'קליסט לפני PR" ו-"אסור!" -->
- [ ] כל הפלט בעברית (כותרת PR, תיאור, הודעות commit, הערות בקוד)
- [ ] אין `print()` — רק `logger`
- [ ] מספרי טלפון מוסתרים בלוגים (`PhoneNumberValidator.mask()`)
- [ ] כל קלט עובר ולידציה
- [ ] קריאות API חיצוני עם Circuit Breaker
- [ ] type hints בכל פונקציה
- [ ] endpoints עם תיעוד OpenAPI
- [ ] בדיקות לפיצ'רים חדשים
- [ ] אין `except Exception: pass`
- [ ] בדיקת authorization לפני כל פעולה
- [ ] ולידציית סטטוס לפני מעבר סטטוס
- [ ] אין N+1 queries
- [ ] בדיקת concurrency — מה קורה בפעולה מקבילית?
- [ ] הודעות שגיאה ברורות בעברית למשתמש
- [ ] מספיק לוגים לדיבאג בפרודקשן
- [ ] אם דו-פלטפורמי — עובד זהה בטלגרם ובוואטסאפ

## השפעות / סיכונים
<!-- השפעה על פרודקשן, ביצועים, אבטחה? תוכנית rollback? -->


## קישורים
- Issue: #
