### PR TITLE
תיקון: /qr/image מחזיר 'already connected' למרות שיש QR לסריקה

### DIFF
--- a/whatsapp_gateway/index.js
+++ b/whatsapp_gateway/index.js
@@ -370,9 +370,12 @@ async function initializeClient() {
             },
         });
 
-        isConnected = true;
-        currentQR = null; // Clear QR once connected
-        console.log('WhatsApp client connected successfully');
+        // בדיקה אם באמת מחובר — statusFind כבר מעדכן isConnected
+        // כש-isLogged/inChat. אם יש QR פעיל, אנחנו עדיין לא מחוברים.
+        if (!currentQR) {
+            isConnected = true;
+        }
+        console.log(`WhatsApp client initialized (connected: ${isConnected})`);
 
         // Listen for incoming messages
         client.onMessage(async (message) => {


### PR DESCRIPTION
create() של WPPConnect חוזר גם כשה-QR עדיין ממתין לסריקה, ושורה 373 דרסה isConnected=true ללא קשר. עכשיו בודקים אם currentQR עדיין קיים לפני שמסמנים חיבור.

https://claude.ai/code/session_01Xr4FXko3w58egHsfFhDYuk

נדחף. הבעיה הייתה ש-`create()` של WPPConnect חוזר גם כשיש QR ממתין לסריקה, ושורה 373 הגדירה `isConnected = true` ללא תנאי — מה שגרם ל-`/qr/image` להחזיר "Already connected" במקום להציג את ה-QR.

עכשיו `isConnected` מוגדר כ-`true` אחרי `create()` רק אם אין `currentQR` פעיל (כלומר `statusFind` כבר סימן חיבור מוצלח). אם יש QR — נשאר `false` עד שה-callback `statusFind` יעדכן אחרי סריקה מוצלחת.