### PR TITLE
fix: העברת photo_file_id לטיפול בהודעות וואטסאפ

### DIFF
--- a/app/api/webhooks/whatsapp.py
+++ b/app/api/webhooks/whatsapp.py
@@ -2110,7 +2110,7 @@ async def whatsapp_webhook(
                     )
                 _driver_handler = _DH(db, platform="whatsapp")
                 response, new_state = await _driver_handler.handle_message(
-                    user, text, None,
+                    user, text, photo_file_id,
                     location_lat=location_lat, location_lng=location_lng,
                 )
                 # שחזור admin context אחרי ה-handler


### PR DESCRIPTION
## תיאור קצר
תיקון באג בטיפול בהודעות וואטסאפ המכילות תמונות. עד כה, מזהה הקובץ של התמונה (`photo_file_id`) לא הועבר ל-handler, מה שגרם להתעלמות מתמונות בהודעות. השינוי מעביר את `photo_file_id` במקום `None` כדי לאפשר טיפול נכון בתמונות.

## שינויים עיקריים
- [x] קוד (Backend / Services)
- [x] בוט וואטסאפ

פירוט:
- בקובץ `app/api/webhooks/whatsapp.py`, שורה 2113: שינוי הקריאה ל-`_driver_handler.handle_message()` להעביר את `photo_file_id` במקום `None` כפרמטר שלישי

## בדיקות
- [x] בדיקות ידניות — הודעות וואטסאפ עם תמונות יעובדו כעת כראוי
- השינוי מתאים לתבנית הקיימת בקוד (ה-handler כבר תומך בפרמטר זה)

## סוג שינוי
- [x] fix: תיקון באג

## צ'קליסט
- [x] כל הפלט בעברית
- [x] אין שינויים בלוגיקה שדורשים logging נוסף
- [x] type hints קיימים בפונקציה
- [x] בדיקת authorization קיימת בקוד הקיים

## השפעות / סיכונים
השינוי מתקן התנהגות קיימת שלא עבדה כראוי. אין סיכון לתאימות לאחור — הטיפול בתמונות יעבוד כעת כמתוכנן. אם לא היו תמונות בהודעות קודם, ההתנהגות תישאר זהה.

## קישורים
- Issue: —

https://claude.ai/code/session_01LgbHSTMsrwf4ESRKgviya6