### PR TITLE
הסרת כותרת "משלוח בצ'יק" מראש הודעות list ב-WPPConnect

### DIFF
--- a/whatsapp_gateway/index.js
+++ b/whatsapp_gateway/index.js
@@ -788,7 +788,7 @@ app.post('/send', async (req, res) => {
                     // - row title עד ~24 תווים
                     // - row description עד ~72 תווים
                     const safeButtonText = truncateByCodepoints(button_text || 'בחר 👆', 20);
-                    const safeTitle = truncateByCodepoints("iDriver • איי דרייבר", 24);
+                    const safeTitle = ' ';
                     const safeDescription = truncateByCodepoints(message, 1024);
 
                     const listPayload = {


### PR DESCRIPTION
בוצע — הכותרת שהופיעה בראש כל הודעת list הוחלפה ברווח (שדה חובה ב-WPPConnect, אבל רווח לא מוצג למשתמש). הכותרת "משלוח בצ'יק" לא תופיע יותר.